### PR TITLE
feat: add workflow metrics tracking and active-workflow concurrency

### DIFF
--- a/hooks/metrics-tracker.sh
+++ b/hooks/metrics-tracker.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# metrics-tracker.sh
+# Event: PostToolUse
+# Matcher: *
+# Scope: Universal (main session + sub-agents)
+#
+# Logs tool input/output character counts to the session log for token estimation.
+# Token estimate = total_chars / 4
+#
+# Appends entries to the session log's Metrics section. At workflow end, skills
+# aggregate these entries for the final summary.
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+VAULT_DIR="${CLAUDE_PROJECT_DIR:-.}/.smith/vault"
+CURRENT_SESSION_FILE="$VAULT_DIR/.current-session"
+
+# Exit silently if no current session
+if [ ! -f "$CURRENT_SESSION_FILE" ]; then
+    exit 0
+fi
+
+SESSION_FILE=$(cat "$CURRENT_SESSION_FILE")
+if [ ! -f "$SESSION_FILE" ]; then
+    exit 0
+fi
+
+# Extract tool name and calculate character counts using python3
+METRICS=$(echo "$INPUT" | python3 -c "
+import sys, json
+
+try:
+    data = json.load(sys.stdin)
+    tool_name = data.get('tool_name', 'Unknown')
+
+    # Serialize input to get character count
+    tool_input = json.dumps(data.get('tool_input', {}))
+
+    # Output may be string or object
+    tool_output = data.get('tool_output', '')
+    if not isinstance(tool_output, str):
+        tool_output = json.dumps(tool_output)
+
+    input_chars = len(tool_input)
+    output_chars = len(tool_output)
+    total = input_chars + output_chars
+
+    print(f'{tool_name}|{input_chars}|{output_chars}|{total}')
+except Exception as e:
+    print(f'Unknown|0|0|0')
+" 2>/dev/null || echo "Unknown|0|0|0")
+
+TOOL_NAME=$(echo "$METRICS" | cut -d'|' -f1)
+INPUT_CHARS=$(echo "$METRICS" | cut -d'|' -f2)
+OUTPUT_CHARS=$(echo "$METRICS" | cut -d'|' -f3)
+TOTAL_CHARS=$(echo "$METRICS" | cut -d'|' -f4)
+
+# Skip if no significant content (less than 10 chars total)
+if [ "$TOTAL_CHARS" -lt 10 ]; then
+    exit 0
+fi
+
+NOW_TIME=$(date -u +"%H:%M:%S")
+
+# Ensure Metrics section exists at the end of the file
+if ! grep -q "^## Metrics$" "$SESSION_FILE" 2>/dev/null; then
+    echo -e "\n## Metrics\n" >> "$SESSION_FILE"
+fi
+
+# Append metric entry (format: timestamp, tool, in chars, out chars, total)
+echo "- \`[$NOW_TIME]\` **$TOOL_NAME** in:${INPUT_CHARS} out:${OUTPUT_CHARS} total:${TOTAL_CHARS}" >> "$SESSION_FILE"
+
+exit 0

--- a/hooks/subagent-vault-writeback.sh
+++ b/hooks/subagent-vault-writeback.sh
@@ -6,17 +6,21 @@
 # Writes sub-agent findings back to .smith/vault/agents/<type>/<identifier>.md
 # on sub-agent completion. Extracts type from the agent description or defaults
 # to "general".
+#
+# Also captures subagent metrics (total_tokens, tool_uses, duration_ms) and
+# logs them to the current session file for workflow summary aggregation.
 
 set -euo pipefail
 
 # Consume stdin (hook input JSON)
 INPUT=$(cat)
 
-VAULT_DIR="$CLAUDE_PROJECT_DIR/.smith/vault"
+VAULT_DIR="${CLAUDE_PROJECT_DIR:-.}/.smith/vault"
 AGENTS_DIR="$VAULT_DIR/agents"
 
 # Timestamp
 NOW_ISO=$(date -u +"%Y-%m-%dT%H:%M:%S")
+NOW_TIME=$(date -u +"%H:%M:%S")
 
 # Extract identifier (agent name or id)
 IDENTIFIER=$(echo "$INPUT" | grep -o '"agent_name"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"agent_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/' || echo "")
@@ -57,17 +61,59 @@ AGENT_FILE="$AGENTS_DIR/$AGENT_TYPE/${SAFE_ID}.md"
 # Extract result/output (truncate to first 500 lines)
 RESULT=$(echo "$INPUT" | grep -o '"result"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"result"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/' || echo "No result captured")
 
-# Append entry
+# Extract metrics (total_tokens, tool_uses, duration_ms) using python3 for reliable JSON parsing
+METRICS=$(echo "$INPUT" | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+    total_tokens = data.get('total_tokens', 0)
+    tool_uses = data.get('tool_uses', 0)
+    duration_ms = data.get('duration_ms', 0)
+    model = data.get('model', 'unknown')
+    print(f'{total_tokens}|{tool_uses}|{duration_ms}|{model}')
+except:
+    print('0|0|0|unknown')
+" 2>/dev/null || echo "0|0|0|unknown")
+
+TOTAL_TOKENS=$(echo "$METRICS" | cut -d'|' -f1)
+TOOL_USES=$(echo "$METRICS" | cut -d'|' -f2)
+DURATION_MS=$(echo "$METRICS" | cut -d'|' -f3)
+MODEL=$(echo "$METRICS" | cut -d'|' -f4)
+
+# Append entry to agent file (with metrics)
 cat >> "$AGENT_FILE" << EOF
 
 ### Invocation — $NOW_ISO
 
 **Task:** $DESCRIPTION
+**Model:** $MODEL
+**Metrics:** tokens:$TOTAL_TOKENS tools:$TOOL_USES duration:${DURATION_MS}ms
 
 **Findings:**
 $RESULT
 
 ---
 EOF
+
+# Also log subagent completion to the current session file for workflow summary
+CURRENT_SESSION_FILE="$VAULT_DIR/.current-session"
+if [ -f "$CURRENT_SESSION_FILE" ]; then
+    SESSION_FILE=$(cat "$CURRENT_SESSION_FILE")
+    if [ -f "$SESSION_FILE" ]; then
+        cat >> "$SESSION_FILE" << EOF
+
+### [$NOW_TIME] Subagent completed: $DESCRIPTION
+
+**Agent:** $IDENTIFIER
+**Type:** $AGENT_TYPE
+**Model:** $MODEL
+**Metrics:**
+- total_tokens: $TOTAL_TOKENS
+- tool_uses: $TOOL_USES
+- duration_ms: $DURATION_MS
+
+EOF
+    fi
+fi
 
 exit 0

--- a/hooks/task-router.sh
+++ b/hooks/task-router.sh
@@ -24,7 +24,11 @@ if [ -z "$MESSAGE" ]; then
 fi
 
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
-ACTIVE_WORKFLOW="$PROJECT_DIR/.smith/vault/.active-workflow"
+
+# Get current branch and sanitize for filename (handles branches like feat/vault-infra)
+BRANCH=$(cd "$PROJECT_DIR" && git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+SAFE_BRANCH=$(echo "$BRANCH" | sed 's/[^a-zA-Z0-9._-]/-/g')
+ACTIVE_WORKFLOW="$PROJECT_DIR/.smith/vault/active-workflows/${SAFE_BRANCH}.yaml"
 
 # Check for manual prefixes first — these work regardless of workflow state
 # Use python3 for reliable prefix detection

--- a/settings/smith-settings-fragment.json
+++ b/settings/smith-settings-fragment.json
@@ -28,6 +28,12 @@
         "hooks": [
           { "type": "command", "command": "bash ~/.claude/hooks/lint-on-save.sh" }
         ]
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          { "type": "command", "command": "bash ~/.claude/hooks/metrics-tracker.sh" }
+        ]
       }
     ],
     "PreToolUse": [

--- a/skills/smith-bugfix/SKILL.md
+++ b/skills/smith-bugfix/SKILL.md
@@ -62,14 +62,22 @@ When triggered by natural language, synthesize the conversation history into a c
 
 ## Phase 1: Branch Safety & Setup
 
-0. **Activate workflow tracking** — create `.smith/vault/.active-workflow`:
-   ```
+0. **Activate workflow tracking** — create a per-branch file in `.smith/vault/active-workflows/`:
+   ```bash
+   # After determining branch name:
+   SAFE_BRANCH=$(echo "$BRANCH" | sed 's/[^a-zA-Z0-9._-]/-/g')
+   mkdir -p .smith/vault/active-workflows
+   cat > .smith/vault/active-workflows/${SAFE_BRANCH}.yaml << EOF
    workflow: smith-bugfix
    feature: <bug description slug>
-   branch: <to be determined>
-   started: <ISO timestamp>
+   branch: $BRANCH
+   started: $(date -u +"%Y-%m-%dT%H:%M:%S")
+   EOF
    ```
-   Update `branch` once the fix branch is created. Clear this file at the end after merge or if abandoned.
+   Clear this file at the end after merge or if abandoned:
+   ```bash
+   rm -f .smith/vault/active-workflows/${SAFE_BRANCH}.yaml
+   ```
 
 1. **Check current branch**:
    ```bash
@@ -293,17 +301,43 @@ bash scripts/health-check.sh
 
 ### 8.2 Display Summary
 
-Output to the user:
-- Fix description
-- PR link (merged)
-- Files modified
-- Test results
-- Any warnings (stashed changes, unrelated test failures)
-- Confirmation that we're back on `main` with services healthy
+Output a workflow summary with aggregated metrics:
+
+```
+=== Bugfix Summary ===
+
+Fix: <fix description>
+Branch: <branch-name>
+Duration: <end_time - started timestamp>
+PR: <PR number> (merged)
+
+Main Session:
+- Estimated tokens: ~<sum of all Metrics entry totals / 4>
+- Tool calls: <count of Metrics entries>
+
+Subagents:
+- Count: <number of "Subagent completed" entries>
+- Total tokens: <sum of subagent total_tokens>
+- Total tool uses: <sum of subagent tool_uses>
+- Total duration: <sum of subagent duration_ms>ms
+
+Files Changed:
+<list from git diff>
+
+Test Results: <pass/fail summary>
+Warnings: <stashed changes, unrelated test failures if any>
+Status: Back on `main` with services healthy
+```
+
+Log this summary to the session log as well.
 
 ## Workflow Cleanup
 
-After the bugfix is merged (or abandoned), clear `.smith/vault/.active-workflow` to deactivate model routing.
+After the bugfix is merged (or abandoned), clear the active-workflow file to deactivate model routing:
+```bash
+SAFE_BRANCH=$(echo "$BRANCH" | sed 's/[^a-zA-Z0-9._-]/-/g')
+rm -f .smith/vault/active-workflows/${SAFE_BRANCH}.yaml
+```
 
 ## Post-Workflow Reflection
 

--- a/skills/smith-build/SKILL.md
+++ b/skills/smith-build/SKILL.md
@@ -41,14 +41,22 @@ This command can be invoked in two ways:
 
 ## Phase 0: Context Discovery
 
-0. **Activate workflow tracking** — create `.smith/vault/.active-workflow`:
-   ```
+0. **Activate workflow tracking** — create a per-branch file in `.smith/vault/active-workflows/`:
+   ```bash
+   BRANCH=$(git rev-parse --abbrev-ref HEAD)
+   SAFE_BRANCH=$(echo "$BRANCH" | sed 's/[^a-zA-Z0-9._-]/-/g')
+   mkdir -p .smith/vault/active-workflows
+   cat > .smith/vault/active-workflows/${SAFE_BRANCH}.yaml << EOF
    workflow: smith-build
    feature: <detected from branch or spec>
-   branch: <current branch>
-   started: <ISO timestamp>
+   branch: $BRANCH
+   started: $(date -u +"%Y-%m-%dT%H:%M:%S")
+   EOF
    ```
-   Clear this file at the end of Phase 7 (after release notes) or on unrecoverable failure.
+   Clear this file at the end of Phase 7 (after release notes) or on unrecoverable failure:
+   ```bash
+   rm -f .smith/vault/active-workflows/${SAFE_BRANCH}.yaml
+   ```
 
 1. **Detect worktree context**:
    ```bash
@@ -412,7 +420,11 @@ If `WORKTREE_MODE=true`:
 
 ### 7.4 Clear Workflow Tracking
 
-Remove `.smith/vault/.active-workflow` to signal the workflow is complete.
+Remove the active-workflow file to signal the workflow is complete:
+```bash
+SAFE_BRANCH=$(echo "$BRANCH" | sed 's/[^a-zA-Z0-9._-]/-/g')
+rm -f .smith/vault/active-workflows/${SAFE_BRANCH}.yaml
+```
 
 ### 7.4.1 Post-Workflow Reflection
 

--- a/skills/smith-debug/SKILL.md
+++ b/skills/smith-debug/SKILL.md
@@ -280,6 +280,30 @@ Would you like me to:
 
 ### If user selects [3] (Close):
 - Update the debug report status to `closed` or `documented`
+- Display workflow summary with aggregated metrics:
+
+  ```
+  === Debug Summary ===
+
+  Issue: <symptom description>
+  Duration: <end_time - session start>
+  Report: <path to debug report>
+
+  Main Session:
+  - Estimated tokens: ~<sum of all Metrics entry totals / 4>
+  - Tool calls: <count of Metrics entries>
+
+  Subagents (Triage):
+  - Count: <number of triage subagents run>
+  - Total tokens: <sum of subagent total_tokens>
+  - Total tool uses: <sum of subagent tool_uses>
+  - Total duration: <sum of subagent duration_ms>ms
+
+  Diagnosis: <root cause summary>
+  Confidence: <confirmed/probable/possible>
+  ```
+
+- Log this summary to the session log
 - Log completion to vault
 
 ## Key Rules

--- a/skills/smith-implement/SKILL.md
+++ b/skills/smith-implement/SKILL.md
@@ -37,14 +37,32 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 ## Workflow Tracking
 
-At the start of implementation, create `.smith/vault/.active-workflow` if it doesn't already exist (it may already be set by `/smith-new` or `/smith-build`):
-```
+At the start of implementation, create a per-branch active-workflow file **only if it doesn't already exist** (it may already be set by `/smith-new` or `/smith-build`):
+```bash
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+SAFE_BRANCH=$(echo "$BRANCH" | sed 's/[^a-zA-Z0-9._-]/-/g')
+ACTIVE_FILE=".smith/vault/active-workflows/${SAFE_BRANCH}.yaml"
+
+# Only create if not already set by parent workflow
+if [ ! -f "$ACTIVE_FILE" ]; then
+  mkdir -p .smith/vault/active-workflows
+  cat > "$ACTIVE_FILE" << EOF
 workflow: smith-implement
 feature: <detected from branch or spec>
-branch: <current branch>
-started: <ISO timestamp>
+branch: $BRANCH
+started: $(date -u +"%Y-%m-%dT%H:%M:%S")
+EOF
+fi
 ```
-Clear `.smith/vault/.active-workflow` when all tasks are complete. If this action was invoked by `/smith-build`, the build action handles cleanup instead.
+
+Clear the active-workflow file when all tasks are complete, **only if smith-implement created it** (not if inherited from parent):
+```bash
+# Only clean up if we created it (check workflow field)
+if grep -q 'workflow: smith-implement' "$ACTIVE_FILE" 2>/dev/null; then
+  rm -f "$ACTIVE_FILE"
+fi
+```
+If this action was invoked by `/smith-build`, the build action handles cleanup instead.
 
 ## Outline
 

--- a/skills/smith-new/SKILL.md
+++ b/skills/smith-new/SKILL.md
@@ -81,15 +81,23 @@ If none of the trigger conditions are met, skip directly to Phase 1. Exploration
 
 The worktree is created after exploration passes (or is skipped). This ensures the user's current working directory and branch are never touched — the entire workflow is isolated from the start.
 
-0. **Activate workflow tracking** — create `.smith/vault/.active-workflow` in the **main repo**:
-   ```
+0. **Activate workflow tracking** — create a per-branch file in `.smith/vault/active-workflows/` in the **main repo**:
+   ```bash
+   # After determining branch name in step 4:
+   SAFE_BRANCH=$(echo "$BRANCH" | sed 's/[^a-zA-Z0-9._-]/-/g')
+   mkdir -p .smith/vault/active-workflows
+   cat > .smith/vault/active-workflows/${SAFE_BRANCH}.yaml << EOF
    workflow: smith-new
-   feature: <to be determined>
-   branch: <to be determined>
-   worktree: <to be determined>
-   started: <ISO timestamp>
+   feature: <feature-name>
+   branch: $BRANCH
+   worktree: $WORKTREE_PATH
+   started: $(date -u +"%Y-%m-%dT%H:%M:%S")
+   EOF
    ```
-   Update `feature`, `branch`, and `worktree` fields once the worktree is created in step 4 below. Clear this file at the end of Phase 6 (after merge) or if the workflow is abandoned.
+   Clear this file at the end of Phase 6 (after merge) or if the workflow is abandoned:
+   ```bash
+   rm -f .smith/vault/active-workflows/${SAFE_BRANCH}.yaml
+   ```
 
 1. **Fetch latest main** (does NOT change the user's current branch):
    ```bash
@@ -109,7 +117,7 @@ The worktree is created after exploration passes (or is skipped). This ensures t
    ```bash
    git worktree add /tmp/smith-<slug> -b <number>-<short-name> origin/main
    ```
-   Store the worktree path (`/tmp/smith-<slug>`) as `WORKTREE_PATH`. Update `.smith/vault/.active-workflow` in the **main repo** with the `feature`, `branch`, and `worktree` fields.
+   Store the worktree path (`/tmp/smith-<slug>`) as `WORKTREE_PATH`. The active-workflow file was already created in step 0 with the branch and worktree info.
 
    **Note**: The user's current branch is completely unaffected. They can be on any branch — `main`, a feature branch, even a detached HEAD — and this workflow will not interfere.
 
@@ -157,7 +165,12 @@ If the branch was created with a placeholder name in Phase 1 (because `$ARGUMENT
 ```bash
 cd $WORKTREE_PATH && git branch -m <old-placeholder-name> <number>-<short-name>
 ```
-Update `.smith/vault/.active-workflow` in the main repo with the final branch name.
+Rename the active-workflow file if the branch name changed:
+   ```bash
+   OLD_SAFE=$(echo "$OLD_BRANCH" | sed 's/[^a-zA-Z0-9._-]/-/g')
+   NEW_SAFE=$(echo "$NEW_BRANCH" | sed 's/[^a-zA-Z0-9._-]/-/g')
+   mv .smith/vault/active-workflows/${OLD_SAFE}.yaml .smith/vault/active-workflows/${NEW_SAFE}.yaml
+   ```
 
 1. **Auto-detect primary system** (reading from worktree):
    - Read all system spec files at `$WORKTREE_PATH/.specify/systems/system-*/spec.md`
@@ -385,7 +398,11 @@ After answers are confirmed. All work continues in `WORKTREE_PATH`. The user's m
       ```bash
       git worktree remove $WORKTREE_PATH
       ```
-   f. **Clear `.smith/vault/.active-workflow`** in the main repo
+   f. **Clear active-workflow file** in the main repo:
+      ```bash
+      SAFE_BRANCH=$(echo "$BRANCH" | sed 's/[^a-zA-Z0-9._-]/-/g')
+      rm -f .smith/vault/active-workflows/${SAFE_BRANCH}.yaml
+      ```
    g. Confirm: "Queued: `<filename>` (priority: `<level>`, complexity: autonomous). Feature branch `<branch-name>` pushed with all spec artifacts. Run `/smith-queue list` to see pending tasks, or the 2am scheduler will pick it up automatically."
    h. **STOP here.** Do NOT launch `/smith-build`.
 
@@ -415,12 +432,44 @@ After answers are confirmed. All work continues in `WORKTREE_PATH`. The user's m
    - Delete the remote feature branch
    - Pull latest main so the local copy is up to date
 
-7. **Clean up worktree:**
+7. **Display workflow summary** with aggregated metrics:
+
+   Read the session log and aggregate all metrics entries and subagent completion entries:
+
+   ```
+   === Workflow Summary ===
+
+   Feature: <feature-name>
+   Branch: <branch-name>
+   Duration: <end_time - started timestamp from active-workflow>
+   PR: <PR number>
+
+   Main Session:
+   - Estimated tokens: ~<sum of all Metrics entry totals / 4>
+   - Tool calls: <count of Metrics entries>
+
+   Subagents:
+   - Count: <number of "Subagent completed" entries>
+   - Total tokens: <sum of subagent total_tokens>
+   - Total tool uses: <sum of subagent tool_uses>
+   - Total duration: <sum of subagent duration_ms>ms
+
+   Files Changed:
+   <list from git diff --name-only main..HEAD>
+   ```
+
+   Log this summary to the session log as well.
+
+8. **Clean up worktree:**
    ```bash
    git worktree remove $WORKTREE_PATH
    ```
 
-8. **Clear workflow tracking** — remove `.smith/vault/.active-workflow` in the main repo
+9. **Clear workflow tracking** — remove the active-workflow file:
+   ```bash
+   SAFE_BRANCH=$(echo "$BRANCH" | sed 's/[^a-zA-Z0-9._-]/-/g')
+   rm -f .smith/vault/active-workflows/${SAFE_BRANCH}.yaml
+   ```
 
 ### Post-Workflow Reflection
 


### PR DESCRIPTION
## Summary

- Add per-branch active-workflow files to support concurrent workflows in different worktrees
- New PostToolUse hook for token usage estimation (character counts / 4)
- Update SubagentStop hook to capture metrics (tokens, tool uses, duration)
- Add end-of-workflow summary with aggregated metrics to primary workflows

## Changes

### Part 1: Active Workflow Concurrency
- Convert `.smith/vault/.active-workflow` (single file) to `.smith/vault/active-workflows/<branch>.yaml`
- Update task-router.sh to check branch-specific files
- Update 5 skills with consistent branch sanitization

### Part 2: Token Usage Estimation
- New `hooks/metrics-tracker.sh` PostToolUse hook
- Appends character counts to session log Metrics section
- Token estimate formula: `total_chars / 4`

### Part 3: Subagent Metrics Logging
- Enhanced `subagent-vault-writeback.sh` to capture `total_tokens`, `tool_uses`, `duration_ms`
- Logs subagent completion entries to session file for aggregation

### Part 4: End-of-Workflow Summary
- Added aggregated metrics summary to smith-new, smith-bugfix, smith-debug
- Shows: duration, main session tokens, tool calls, subagent totals, files changed

## Files Changed

- `hooks/metrics-tracker.sh` (new)
- `hooks/subagent-vault-writeback.sh`
- `hooks/task-router.sh`
- `settings/smith-settings-fragment.json`
- `skills/smith-new/SKILL.md`
- `skills/smith-bugfix/SKILL.md`
- `skills/smith-build/SKILL.md`
- `skills/smith-implement/SKILL.md`
- `skills/smith-debug/SKILL.md`

## Test plan

- [ ] Run two concurrent workflows in different worktrees - verify separate tracking files
- [ ] Run a workflow and check session log for Metrics section entries
- [ ] Run smith-debug (spawns 4 subagents) and verify subagent metrics logged
- [ ] Run smith-bugfix and verify final summary includes all metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)