### PR TITLE
fix: add Post-Workflow Reflection to smith-debug

### DIFF
--- a/skills/smith-debug/SKILL.md
+++ b/skills/smith-debug/SKILL.md
@@ -311,6 +311,33 @@ Would you like me to:
 - The full `=== Workflow Summary ===` block is appended to the session log file automatically by the `workflow-summary.sh` Stop hook once the active-workflow file is cleaned up — that's for audit only, do not duplicate it in chat
 - Log completion to vault
 
+## Post-Workflow Reflection
+
+After workflow completion (regardless of which Phase 6 option the user selected), trigger a Ledger reflection if enabled. Debug runs surface valuable signal — root causes, false hypotheses, diagnostic dead-ends — that should feed back into `antipatterns.md` and `edge-cases.md` for future runs.
+
+1. Read `.smith/config.json` — if `ledger.auto_reflect` is `true` (default), proceed
+2. Launch a **non-blocking** background sub-agent using the configured reflection model (default: Haiku):
+   - Pass: current session log path, `.smith/vault/ledger/` path, and the debug report path
+   - The sub-agent runs the `smith-reflect` workflow
+   - Do NOT wait for the sub-agent to complete
+3. If `.smith/config.json` is missing or `ledger.auto_reflect` is `false`, skip silently
+
+### Post-Reflection Reconciliation Check
+
+After reflection completes (or is skipped):
+
+1. Read `.smith/config.json` — if `ledger.reconcile.auto_reconcile` is `false`, skip
+2. Read `.smith/vault/ledger/.meta.json` — check signals against thresholds:
+   - `estimated_tokens > thresholds.total_tokens_max` (default 30000)
+   - `context_budget_violations > thresholds.context_violations_threshold` (default 3)
+   - `reinforcements_since_reconcile > thresholds.reinforcements_threshold` (default 50)
+3. Check minimum interval: if `last_reconcile` is less than `minimum_hours_between_reconciles` (default 6) hours ago, skip
+4. If any threshold exceeded AND minimum interval has passed:
+   - Launch a **non-blocking** background sub-agent using the configured `reconcile_model` (default: Haiku)
+   - Pass: "Run /smith-ledger reconcile on this project"
+   - Do NOT wait for the sub-agent to complete
+5. If no threshold exceeded, `.meta.json` is missing, or config is missing, skip silently
+
 ## Key Rules
 
 - **Read-only**: This workflow NEVER modifies application code, configs, or Docker services


### PR DESCRIPTION
## Summary

smith-debug was the only primary workflow with no reflection or reconciliation wiring. Adds the standard `Post-Workflow Reflection` + `Post-Reflection Reconciliation Check` sections, matching the structure already in smith-new and smith-bugfix.

## What was broken

Debug runs surface high-value signal — confirmed root causes, ruled-out hypotheses, dead-ends — but none of it was being fed back into the Ledger. So a future debug session in the same project couldn't benefit from past investigations. Reflection: missing. Reconciliation check: missing.

## What changed

- **skills/smith-debug/SKILL.md** — added two new sections immediately after the Phase 6 decision gate, cloned from smith-new's structure (same fields, same thresholds, same non-blocking subagent pattern). The reflection sub-agent now also receives the debug report path so it can extract pattern/antipattern/edge-case entries from confirmed diagnoses.

## Context

This was the third sub-task of the original "expand ledger reads" plan. The other two (smith-new ledger expansion to all 5 files + smith-debug `Ledger Context` section) were unintentionally swept into [PR #6](https://github.com/ATTCKDigital/smith/pull/6) when a concurrent dev session ran `git add` on those files while my edits were uncommitted in the shared working tree. Net effect is the same — all three changes ship — but worth flagging as a smith-bugfix process gap (smith-bugfix doesn't create its own worktree, so concurrent sessions can collide).

## Test plan

- [x] Section structure matches the canonical pattern in smith-new (lines 444-465) and smith-bugfix
- [x] No other files modified — only smith-debug
- [x] Re-install via scripts/install.sh after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)