### PR TITLE
fix: restructure smith-new step 5 so totals-only bash call is surfaced

### DIFF
--- a/skills/smith-new/SKILL.md
+++ b/skills/smith-new/SKILL.md
@@ -431,13 +431,7 @@ After answers are confirmed. All work continues in `WORKTREE_PATH`. The user's m
    - This runs as a subagent chain (see smith-build skill)
    - Wait for completion
 
-5. **Display final summary** to the user. Lead the message with "Feature `<name>` complete. Here's the summary:" and include:
-   - Feature name and branch
-   - Files created/modified
-   - PR link
-   - Release notes summary
-   - Link to `specs/<feature>/release.md`
-   - **Token and duration totals** — run `bash hooks/workflow-summary.sh --totals-only` and paste the two lines it prints (`Total tokens used: ~<n>` and `Total duration: <d>`) verbatim at the bottom of the summary. Run this BEFORE step 9 (clearing the active-workflow file), otherwise the Stop hook will also append its full block to the session log during the same Stop event — behavior is still correct, but running it now guarantees the numbers are fresh.
+5. **Display final summary** to the user. Emit a chat message that starts with "Feature `<name>` complete. Here's the summary:" and includes the feature name and branch, files created/modified, PR link, release notes summary, and link to `specs/<feature>/release.md`. At the bottom, run `bash hooks/workflow-summary.sh --totals-only` and paste the two lines it prints (`Total tokens used: ~<n>` and `Total duration: <d>`) verbatim — do this BEFORE step 9 (clearing the active-workflow file) so the numbers are fresh. The bash invocation is a required action, not an optional extra — the two totals lines must appear in the chat message.
 
 6. **Merge PR** from the **main repo directory** (not the worktree — avoids "main already checked out" errors):
    **IMPORTANT**: Always run `gh pr merge` from the **primary repo directory**.


### PR DESCRIPTION
## Summary
- Rewrite `skills/smith-new/SKILL.md` step 5 as a single imperative paragraph
- Remove the nested sub-bullet structure that caused the bash call to be skipped

## What was broken
The 091dd392 fix intended to make `/smith-new`'s final chat summary include `Total tokens used` and `Total duration` via an inline `bash hooks/workflow-summary.sh --totals-only` call. It still didn't work — confirmed on the `083-case-study-selection-ux` run (armory PR #274): no `workflow-summary.sh` invocation appears in the session log between build completion and the next workflow, and the final chat message lacked the totals.

Root cause (see `specs/debug/debug-2026-04-14-smith-new-missing-totals.md`): step 5 listed the bash call as the 6th sub-bullet in a 6-item content-assembly list. The first five items were pure content (feature name, files, PR link, release notes, spec link). The model pattern-matched the bash bullet as another content item and never issued the tool call.

smith-bugfix's equivalent step (Phase 8.2) and smith-debug's Phase 6 close path both surfaced the totals correctly because they express the bash call as prose/imperative rather than a buried sub-bullet.

## What changed
- `skills/smith-new/SKILL.md` — step 5 restructured to mirror smith-bugfix's Phase 8.2 wording. Content items listed inline, then an explicit "At the bottom, run ... and paste the two lines verbatim" sentence, with a closing reinforcement that the bash call is a required action.

Scope intentionally narrow — does not touch the unrelated invocation-timestamp template issue (bug 2 in the debug report), which will be a separate pass.

## Test plan
- [x] Markdown-only change, no unit/E2E tests applicable
- [ ] Next `/smith-new` run should emit `Total tokens used: ~<n>` and `Total duration: <d>` in the final chat message

🤖 Generated with [Claude Code](https://claude.com/claude-code)