### PR TITLE
fix: clear-active-workflow.sh helper to coexist with Bash(rm:*) deny

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,12 @@ The security guard hooks block:
 
 The scheduler runs bash scripts via macOS `launchd`. You can audit the full script at `scheduler/smith-scheduler.sh` before enabling it.
 
+### Coexistence with a `Bash(rm:*)` deny rule
+
+Some projects add `"Bash(rm:*)"` to the `deny` list of `.claude/settings.json` as a safety rail against accidental deletion. In Claude Code, `deny` supersedes `allow`, so a workflow can't route around the deny rule by whitelisting a narrower `rm` pattern.
+
+To let Smith clean up its per-branch active-workflow markers under that rule, `/smith` ships a narrow helper at `.specify/scripts/bash/clear-active-workflow.sh`. The helper only unlinks a single file matching `.smith/vault/active-workflows/<safe-branch>.yaml`, never globs, never recurses, and refuses any path that escapes the active-workflows directory. Every Smith workflow skill calls it instead of inline `rm`, and the default project permissions allow-list it explicitly — so the `Bash(rm:*)` deny stays in place and cleanup still works.
+
 See [docs/security-model.md](docs/security-model.md) for a detailed breakdown of the threat model and mitigations.
 
 ---

--- a/skills/smith-bugfix/SKILL.md
+++ b/skills/smith-bugfix/SKILL.md
@@ -296,9 +296,10 @@ Run from the primary repo directory. On success, remove the worktree; on failure
 cd "$PRIMARY_REPO"
 # Success path: remove the worktree (the branch was already deleted by --delete-branch on merge)
 git worktree remove "$WORKTREE_PATH"
-# Always: clear the active-workflow marker so future sessions know this branch is free
-SAFE_BRANCH=$(echo "$BRANCH" | sed 's/[^a-zA-Z0-9._-]/-/g')
-rm -f .smith/vault/active-workflows/${SAFE_BRANCH}.yaml
+# Always: clear the active-workflow marker so future sessions know this branch is free.
+# Use the shipped helper so this works even on projects that set Bash(rm:*) in the
+# deny list of .claude/settings.json.
+.specify/scripts/bash/clear-active-workflow.sh "$BRANCH"
 ```
 
 If `git worktree remove` fails because of uncommitted local edits (shouldn't happen on the success path, but can on forced cleanup), fall back to `git worktree remove --force "$WORKTREE_PATH"` and warn the user that any uncommitted changes in the worktree are being discarded.

--- a/skills/smith-build/SKILL.md
+++ b/skills/smith-build/SKILL.md
@@ -66,9 +66,9 @@ This command can be invoked in two ways:
    started: $(date -u +"%Y-%m-%dT%H:%M:%S")
    EOF
    ```
-   Clear this file at the end of Phase 7 (after release notes) or on unrecoverable failure:
+   Clear this file at the end of Phase 7 (after release notes) or on unrecoverable failure. Use the shipped helper so this works even on projects that deny `Bash(rm:*)`:
    ```bash
-   rm -f .smith/vault/active-workflows/${SAFE_BRANCH}.yaml
+   .specify/scripts/bash/clear-active-workflow.sh "$BRANCH"
    ```
 
 1. **Detect worktree context**:
@@ -433,10 +433,9 @@ If `WORKTREE_MODE=true`:
 
 ### 7.4 Clear Workflow Tracking
 
-Remove the active-workflow file to signal the workflow is complete:
+Remove the active-workflow file to signal the workflow is complete. Use the shipped helper, which coexists with a broad `Bash(rm:*)` deny rule:
 ```bash
-SAFE_BRANCH=$(echo "$BRANCH" | sed 's/[^a-zA-Z0-9._-]/-/g')
-rm -f .smith/vault/active-workflows/${SAFE_BRANCH}.yaml
+.specify/scripts/bash/clear-active-workflow.sh "$BRANCH"
 ```
 
 ### 7.4.1 Post-Workflow Reflection

--- a/skills/smith-implement/SKILL.md
+++ b/skills/smith-implement/SKILL.md
@@ -55,11 +55,11 @@ EOF
 fi
 ```
 
-Clear the active-workflow file when all tasks are complete, **only if smith-implement created it** (not if inherited from parent):
+Clear the active-workflow file when all tasks are complete, **only if smith-implement created it** (not if inherited from parent). Use the shipped helper so this works on projects that deny `Bash(rm:*)`:
 ```bash
 # Only clean up if we created it (check workflow field)
 if grep -q 'workflow: smith-implement' "$ACTIVE_FILE" 2>/dev/null; then
-  rm -f "$ACTIVE_FILE"
+  .specify/scripts/bash/clear-active-workflow.sh "$BRANCH"
 fi
 ```
 If this action was invoked by `/smith-build`, the build action handles cleanup instead.

--- a/skills/smith-new/SKILL.md
+++ b/skills/smith-new/SKILL.md
@@ -107,9 +107,9 @@ The worktree is created after exploration passes (or is skipped). This ensures t
    started: $(date -u +"%Y-%m-%dT%H:%M:%S")
    EOF
    ```
-   Clear this file at the end of Phase 6 (after merge) or if the workflow is abandoned:
+   Clear this file at the end of Phase 6 (after merge) or if the workflow is abandoned. Use the shipped helper so this works even on projects that set `Bash(rm:*)` in the deny list:
    ```bash
-   rm -f .smith/vault/active-workflows/${SAFE_BRANCH}.yaml
+   .specify/scripts/bash/clear-active-workflow.sh "$BRANCH"
    ```
 
 1. **Fetch latest main** (does NOT change the user's current branch):
@@ -414,10 +414,9 @@ After answers are confirmed. All work continues in `WORKTREE_PATH`. The user's m
       ```bash
       git worktree remove $WORKTREE_PATH
       ```
-   f. **Clear active-workflow file** in the main repo:
+   f. **Clear active-workflow file** in the main repo (via the shipped helper, which coexists with a broad `Bash(rm:*)` deny rule):
       ```bash
-      SAFE_BRANCH=$(echo "$BRANCH" | sed 's/[^a-zA-Z0-9._-]/-/g')
-      rm -f .smith/vault/active-workflows/${SAFE_BRANCH}.yaml
+      .specify/scripts/bash/clear-active-workflow.sh "$BRANCH"
       ```
    g. Confirm: "Queued: `<filename>` (priority: `<level>`, complexity: autonomous). Feature branch `<branch-name>` pushed with all spec artifacts. Run `/smith-queue list` to see pending tasks, or the 2am scheduler will pick it up automatically."
    h. **STOP here.** Do NOT launch `/smith-build`.
@@ -450,10 +449,9 @@ After answers are confirmed. All work continues in `WORKTREE_PATH`. The user's m
    git worktree remove $WORKTREE_PATH
    ```
 
-9. **Clear workflow tracking** — remove the active-workflow file:
+9. **Clear workflow tracking** — remove the active-workflow file via the shipped helper (safe against a `Bash(rm:*)` deny rule):
    ```bash
-   SAFE_BRANCH=$(echo "$BRANCH" | sed 's/[^a-zA-Z0-9._-]/-/g')
-   rm -f .smith/vault/active-workflows/${SAFE_BRANCH}.yaml
+   .specify/scripts/bash/clear-active-workflow.sh "$BRANCH"
    ```
 
 ### Post-Workflow Reflection

--- a/skills/smith/SKILL.md
+++ b/skills/smith/SKILL.md
@@ -493,11 +493,14 @@ If no `.claude/settings.json` exists, create one with sensible defaults:
       "Bash(git log:*)",
       "Bash(git diff:*)",
       "Bash(git branch:*)",
-      "Bash(./.specify/scripts/*:*)"
+      "Bash(./.specify/scripts/*:*)",
+      "Bash(.specify/scripts/bash/clear-active-workflow.sh:*)"
     ]
   }
 }
 ```
+
+The `clear-active-workflow.sh` entry is listed explicitly so Smith workflow cleanup still works on projects that add `Bash(rm:*)` to the `deny` list as a safety rail. The helper is narrow (single file, no globs, path-escape guarded) and lets skills remove the active-workflow marker without weakening the deny rule.
 
 Add framework-specific permissions based on detected stack:
 - npm projects: `"Bash(npm run:*)"`, `"Bash(npm install:*)"`
@@ -512,7 +515,7 @@ Add monorepo-specific permissions based on detected orchestration tool:
 - Lerna: `"Bash(lerna:*)"`, `"Bash(npx lerna:*)"`
 - Rush: `"Bash(rush:*)"`
 
-If `.claude/settings.json` already exists, do NOT overwrite — inform the user they may want to add the `.specify/scripts` permission manually.
+If `.claude/settings.json` already exists, do NOT overwrite — inform the user they may want to add the `.specify/scripts` permission manually, plus `Bash(.specify/scripts/bash/clear-active-workflow.sh:*)` if their config includes a broad `Bash(rm:*)` deny rule (needed so Smith workflow cleanup can remove active-workflow markers).
 
 #### 4.7 Create `.gitignore` Entries
 

--- a/skills/smith/scripts/clear-active-workflow.sh
+++ b/skills/smith/scripts/clear-active-workflow.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# clear-active-workflow.sh — safely remove a single active-workflow marker file.
+#
+# Exists so Smith skills can clean up .smith/vault/active-workflows/<branch>.yaml
+# on projects whose .claude/settings.json denies `Bash(rm:*)` as a safety rail.
+# This helper never globs, never recurses, and refuses any path that escapes
+# .smith/vault/active-workflows/.
+
+set -eu
+
+BRANCH="${1:-}"
+[ -n "$BRANCH" ] || { echo "usage: $(basename "$0") <branch-name>" >&2; exit 2; }
+
+SAFE=$(printf '%s' "$BRANCH" | sed 's/[^a-zA-Z0-9._-]/-/g')
+case "$SAFE" in
+    ''|.|..) echo "error: invalid sanitized name: '$SAFE'" >&2; exit 3 ;;
+esac
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) \
+    || { echo "error: not inside a git working tree" >&2; exit 4; }
+
+DIR="$REPO_ROOT/.smith/vault/active-workflows"
+TARGET="$DIR/$SAFE.yaml"
+
+# No-op when nothing to clean (also handles the case where DIR doesn't exist).
+[ -e "$TARGET" ] || [ -L "$TARGET" ] || exit 0
+
+EXPECTED=$(cd "$DIR" && pwd -P)
+ACTUAL=$(cd "$(dirname "$TARGET")" && pwd -P)
+[ "$EXPECTED" = "$ACTUAL" ] \
+    || { echo "error: target escapes active-workflows dir" >&2; exit 5; }
+
+if [ -L "$TARGET" ]; then
+    LINK=$(readlink "$TARGET")
+    RESOLVED=$(cd "$DIR" && cd "$(dirname "$LINK")" 2>/dev/null && pwd -P) || RESOLVED=""
+    case "$RESOLVED" in
+        "$EXPECTED"|"$EXPECTED"/*) ;;
+        *) echo "error: symlink resolves outside active-workflows" >&2; exit 6 ;;
+    esac
+fi
+
+unlink "$TARGET"


### PR DESCRIPTION
## Summary
- Replace inline `rm -f .smith/vault/active-workflows/<branch>.yaml` in every Smith workflow skill with a shipped helper (`skills/smith/scripts/clear-active-workflow.sh` → installed per-project at `.specify/scripts/bash/clear-active-workflow.sh`).
- `/smith` init now allow-lists the helper in default `.claude/settings.json`, and README §Security documents why it exists.

## What was broken
On projects that add `"Bash(rm:*)"` to the `deny` list of `.claude/settings.json` as a safety rail, the workflow-cleanup step (e.g. `rm -f .smith/vault/active-workflows/${SAFE_BRANCH}.yaml`) was blocked. In Claude Code `deny` supersedes `allow`, so the skill couldn't route around it. Stale `.yaml` markers accumulated and misled `task-router.sh`/`workflow-summary.sh` on subsequent sessions.

## What changed
- `skills/smith/scripts/clear-active-workflow.sh` (new, 42 lines). Takes one arg (unsanitized branch), sanitizes it, resolves repo root via `git rev-parse --show-toplevel`, refuses traversal (rejects `.`/`..`/empty after sanitization, requires target's parent dir realpath to equal the active-workflows dir, rejects symlinks pointing outside), unlinks one file only. No-op if missing. Bash + POSIX tools only.
- `skills/smith-bugfix/SKILL.md`, `skills/smith-new/SKILL.md` (x3), `skills/smith-build/SKILL.md` (x2), `skills/smith-implement/SKILL.md` — all `rm -f` cleanup call-sites replaced with `.specify/scripts/bash/clear-active-workflow.sh "$BRANCH"`.
- `skills/smith/SKILL.md` §4.6 — default `.claude/settings.json` template gains `Bash(.specify/scripts/bash/clear-active-workflow.sh:*)` in its `allow` list, with a note explaining the coexistence with `Bash(rm:*)` deny.
- `README.md` §Security — new subsection "Coexistence with a `Bash(rm:*)` deny rule" explaining the helper.

## Manual verification
Ran the helper against all four test cases the task called out plus two more:
- normal branch name → unlinks, exit 0 ✓
- nonexistent file → no-op, exit 0 ✓
- branch with `/` (`feat/new-thing`) → sanitizes to `feat-new-thing`, unlinks, exit 0 ✓
- malicious `../../etc/passwd` → sanitizes to `..-..-etc-passwd`, no matching file, exit 0 (no escape) ✓
- literal `..` → exit 3 "invalid sanitized name" ✓
- empty / missing arg → exit 2 with usage ✓

## Test plan
- [x] Helper unit behavior verified manually (see above)
- [x] Every `rm .*active-workflows` call-site in `skills/` now calls the helper (grep confirmed)
- [x] Default settings template allow-lists the helper path
- [ ] Downstream projects with `Bash(rm:*)` deny should run `/smith` (or manually add the allow entry) to pick up the new permission

🤖 Generated with [Claude Code](https://claude.com/claude-code)