### PR TITLE
fix: resolve workflow_summary_lib from global ~/.claude/hooks, not sibling-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `hooks/workflow-summary.sh` now resolves `workflow_summary_lib.py` via a priority chain (`$CLAUDE_HOOKS_DIR` → `~/.claude/hooks` → sibling of `$0`) instead of only the sibling directory. This allows a single installed copy at `~/.claude/hooks/workflow-summary.sh` to serve as a Stop hook across all projects without each project vendoring its own copy of the Python lib and `pricing.json`. If none of the candidates contain the lib, the wrapper prints a stderr note and exits 0 (consistent with existing degrade-gracefully behavior).
 - The chars/4 character-count estimate is no longer displayed as "Estimated tokens" in the workflow summary. The per-tool `metrics-tracker.sh` log lines remain unchanged (useful for spotting heavy tool uses), but the summary block now uses real Anthropic-reported token counts from the parent-session JSONL instead.
 - Active workflow tracking now uses per-branch files (`.smith/vault/active-workflows/<branch>.yaml`) to support concurrent workflows in different worktrees
 - `subagent-vault-writeback.sh` enhanced to capture and log subagent metrics

--- a/hooks/workflow-summary.sh
+++ b/hooks/workflow-summary.sh
@@ -87,7 +87,26 @@ if [ "$TOTALS_ONLY" = "0" ]; then
 fi
 
 # Hand off to the Python library.
-HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+#
+# Resolve the hooks dir that contains workflow_summary_lib.py. Priority:
+#   1. $CLAUDE_HOOKS_DIR if it contains the lib
+#   2. ~/.claude/hooks/ if it contains the lib
+#   3. Sibling dir of this script (repo checkout / bundled use)
+# This lets a single copy of the .sh live in either location.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOK_DIR=""
+for candidate in "${CLAUDE_HOOKS_DIR:-}" "$HOME/.claude/hooks" "$SCRIPT_DIR"; do
+    if [ -n "$candidate" ] && [ -f "$candidate/workflow_summary_lib.py" ]; then
+        HOOK_DIR="$candidate"
+        break
+    fi
+done
+
+if [ -z "$HOOK_DIR" ]; then
+    echo "workflow-summary.sh: cannot locate workflow_summary_lib.py (checked \$CLAUDE_HOOKS_DIR, ~/.claude/hooks, $SCRIPT_DIR)" >&2
+    exit 0
+fi
+
 SESSION_FILE="$SESSION_FILE" \
   PROJECT_ROOT="$PROJECT_ROOT" \
   TOTALS_ONLY="$TOTALS_ONLY" \


### PR DESCRIPTION
## Summary
- `hooks/workflow-summary.sh` previously derived `HOOK_DIR` from `dirname "$0"`, requiring `workflow_summary_lib.py` to live beside the `.sh`. That forced every project using this as a Stop hook to vendor its own copy of the lib + `pricing.json`.
- Wrapper now resolves the lib via a priority chain: `$CLAUDE_HOOKS_DIR` → `~/.claude/hooks` → sibling of `$0`. First candidate containing `workflow_summary_lib.py` wins.
- Missing-lib path writes a stderr note and exits 0, matching existing degrade-gracefully behavior on missing session/vault inputs.

Lets a single installed copy at `~/.claude/hooks/workflow-summary.sh` serve as the global Stop hook across all projects.

## Test plan
- [x] Syncing script + lib + pricing.json to `~/.claude/hooks/` and running `bash ~/.claude/hooks/workflow-summary.sh --totals-only` from `/tmp` (outside the repo) exits 0 with no crash
- [x] `PYTHONPATH=~/.claude/hooks python3 -c "import workflow_summary_lib"` resolves to the global path
- [ ] Next real workflow completion in this repo (where the lib IS a sibling) still emits the Stop-hook `=== Workflow Summary ===` block — resolver should pick sibling when global lib is absent or vice versa
- [ ] Setting `CLAUDE_HOOKS_DIR=/some/other/dir` with a lib there overrides both defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)