### PR TITLE
Prep repo for distribution via npx skills add attck/smith

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Install via `npx skills add attck/smith` — new distribution path that copies all 26 skills into `~/.claude/skills/` without requiring the curl installer. Skills-only; hooks and scheduler still require the bundled installer.
+- New skill in the public distribution: `/smith-audit` — cross-system audit orchestrator. Previously only in the agency-internal skill set; now shipped with the public Smith distribution.
 - New skill: `/smith-explore` — pre-change impact analysis for features touching core infrastructure
 - New hook: `metrics-tracker.sh` — PostToolUse hook that captures character counts for token estimation
 - Workflow metrics summary — primary workflows (smith-new, smith-bugfix, smith-debug) now display aggregated metrics at completion: estimated tokens, tool calls, subagent stats, duration
@@ -22,11 +24,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- 7 skills (`smith-bank`, `smith-explore`, `smith-ledger`, `smith-migrate-specs`, `smith-report`, `smith-todo`, `smith-vault`) were silently skipped by `npx skills add . --list` because their `argument-hint:` frontmatter value started with `[` followed by multiple space-separated bracketed groups — a YAML flow-sequence construct the `skills` CLI parser rejects. Wrapped all affected values in double quotes so YAML treats them as plain string scalars. Claude Code's own parser already tolerated the unquoted form, so local invocation was never affected; only the external CLI was. See [specs/013-distribution-readiness/research.md](specs/013-distribution-readiness/research.md) for the diagnosis.
 - `Total tokens used` and `Total duration` now appear in the user-facing "Feature/Bugfix/Debug complete" chat message. Previously these only landed in the session log file because the Stop hook's stdout doesn't flow into the assistant message that already shipped. Skills (`/smith-new`, `/smith-bugfix`, `/smith-debug`) now invoke `workflow-summary.sh --totals-only` and paste the two lines into their final summary before Stop fires. The full `=== Workflow Summary ===` audit block continues to be appended to the session log file by the Stop hook
 - Workflow token count was previously a raw sum of `input + output + cache_create + cache_read` at 1× weights across all models, which inflated the number 3–10× vs. what Anthropic actually bills (cache reads are 0.1× and cost varies by model tier). The summary now displays normalized tokens (fixed-weight formula) and estimated USD cost (per-model pricing lookup), with the raw breakdown relegated to the session-log audit block. Addresses the observation that a single smith-new workflow could show 30M+ tokens — a figure that was technically correct per the formula but misleadingly high for a public repo
 
 ### Changed
 
+- **Renamed skill:** `/smith.init` → `/smith`. The `skills/smith/SKILL.md` frontmatter now declares `name: smith` (previously `name: smith.init`), matching the folder name. Invocations of `/smith.init` no longer match; use `/smith` instead. This aligns with the `skills` CLI's expected folder/name convention.
 - `hooks/workflow-summary.sh` now resolves `workflow_summary_lib.py` via a priority chain (`$CLAUDE_HOOKS_DIR` → `~/.claude/hooks` → sibling of `$0`) instead of only the sibling directory. This allows a single installed copy at `~/.claude/hooks/workflow-summary.sh` to serve as a Stop hook across all projects without each project vendoring its own copy of the Python lib and `pricing.json`. If none of the candidates contain the lib, the wrapper prints a stderr note and exits 0 (consistent with existing degrade-gracefully behavior).
 - The chars/4 character-count estimate is no longer displayed as "Estimated tokens" in the workflow summary. The per-tool `metrics-tracker.sh` log lines remain unchanged (useful for spotting heavy tool uses), but the summary block now uses real Anthropic-reported token counts from the parent-session JSONL instead.
 - Active workflow tracking now uses per-branch files (`.smith/vault/active-workflows/<branch>.yaml`) to support concurrent workflows in different worktrees

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-[![25 Skills](https://img.shields.io/badge/skills-25-brightgreen.svg)](skills/)
+[![26 Skills](https://img.shields.io/badge/skills-26-brightgreen.svg)](skills/)
 [![Claude Code](https://img.shields.io/badge/Claude-Code-blueviolet.svg)](https://claude.ai/code)
 
 # Smith
@@ -15,32 +15,50 @@ _See [smith.attck.com](https://smith.attck.com) for a walkthrough._
 
 Claude Code is a powerful AI coding assistant, but it has no built-in workflow structure. Developers jump straight from a vague idea to generated code with no specification, no plan, and no audit trail. The result is hard to review, harder to maintain, and impossible to trace back to requirements. When something goes wrong — and it will — there is no record of what was intended, what was decided, or why.
 
-Smith fixes this by adding 25 skills that encode a full development workflow into Claude Code. The pipeline flows from **spec to plan to tasks to implementation to review to ship**. Every step produces a versioned artifact inside a `.specify/` directory in your project. Claude reads the output of each step as input to the next, so context accumulates instead of evaporating. You never have to re-explain what you're building.
+Smith fixes this by adding 26 skills that encode a full development workflow into Claude Code. The pipeline flows from **spec to plan to tasks to implementation to review to ship**. Every step produces a versioned artifact inside a `.specify/` directory in your project. Claude reads the output of each step as input to the next, so context accumulates instead of evaporating. You never have to re-explain what you're building.
 
 The outcome: you talk to Claude about what you want to build, Smith handles the structured process, and you get a merged PR with full traceability from idea to code. Hooks log every session automatically and guard against common mistakes — dangerous shell commands, secret exposure, writes to sensitive files. A scheduler can process queued tasks overnight. Everything runs locally on your machine, nothing phones home, and every artifact is a plain text file you can read, diff, and version-control.
 
 ---
 
-## Quick Start
+## Getting Started
+
+### Install via the `skills` CLI (skills only)
+
+```bash
+npx skills add attck/smith
+```
+
+This is the fastest path — it copies all 26 Smith skills into `~/.claude/skills/` and nothing else. Use this if you only want the Smith workflow commands.
+
+**To update:** re-run the same command. `npx skills add` is idempotent.
+
+**To verify:** open Claude Code and type `/smith` — if it autocompletes, you're set.
+
+### Install via the bundled installer (skills + hooks + scheduler)
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/ATTCKDigital/smith/main/scripts/install.sh | bash
 ```
 
-Then open any new or existing project in your terminal and run `/smith` to initialize the vault, bank, and ledger for that project. Once initialized, run `/smith-new` and describe what you want to build. Smith walks you through requirements, planning, task breakdown, implementation, and PR creation — all without leaving the terminal.
+Use this for the full Smith experience. In addition to the skills, it wires up the security / logging hooks and (optionally) the macOS scheduler LaunchAgent. See [Installation](#installation) for details.
 
-> **Note:** `install.sh` is a one-time global setup that installs skills, hooks, and the scheduler into `~/.claude/`. Running `/smith` is a separate per-project step that must be done once in each project before using other commands.
+### First run
+
+Once installed, open any new or existing project in your terminal and run `/smith` to initialize the vault, bank, and ledger for that project. Once initialized, run `/smith-new` and describe what you want to build. Smith walks you through requirements, planning, task breakdown, implementation, and PR creation — all without leaving the terminal.
+
+> **Note:** Installation is a one-time global setup into `~/.claude/`. Running `/smith` is a separate per-project step that must be done once in each project before using other commands.
 
 ---
 
 ## What's Inside
 
-### Skills (25)
+### Skills (26)
 
 | Category | Commands | Description |
 |---|---|---|
 | Feature workflow | `/smith-new`, `/smith-explore`, `/smith-specify`, `/smith-clarify`, `/smith-plan`, `/smith-tasks`, `/smith-analyze`, `/smith-implement`, `/smith-build`, `/smith-bugfix`, `/smith-checklist`, `/smith-finish` | End-to-end feature development pipeline |
-| Debugging | `/smith-debug` | Diagnostic investigation with structured evidence gathering |
+| Debugging and audit | `/smith-debug`, `/smith-audit` | Diagnostic investigation and cross-system audit reporting |
 | Knowledge and vault | `/smith-vault`, `/smith-bank`, `/smith-queue`, `/smith-todo`, `/smith-ledger`, `/smith-reflect` | Persistent session logs, idea storage, task queuing, and accumulated learning |
 | Reporting | `/smith-report`, `/smith-taskstoissues` | Client-facing reports and GitHub issue generation |
 | Meta | `/smith`, `/smith-constitution`, `/smith-migrate-specs`, `/smith-help` | Project initialization, governance, and reference |
@@ -123,7 +141,7 @@ cd smith
 The installer is a **one-time global setup** — it installs Smith into `~/.claude/` and does not modify any project.
 
 - Backs up your existing `~/.claude/settings.json`
-- Copies all 25 skills to `~/.claude/skills/`
+- Copies all 26 skills to `~/.claude/skills/`
 - Copies all 8 hooks to `~/.claude/hooks/`
 - Merges hook configuration into `settings.json` (requires `jq`)
 - Optionally installs the macOS scheduler LaunchAgent

--- a/skills/smith-audit/SKILL.md
+++ b/skills/smith-audit/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: smith-audit
+description: Run a comprehensive audit on a specific system or all systems. Prompts for system selection, then runs all sub-audits and produces a unified report.
+---
+
+# SpecKit Audit — Umbrella Command
+
+Run a full-spectrum audit on a specific system or across all systems. This command orchestrates all sub-audits and produces a unified report.
+
+**Arguments:** $ARGUMENTS
+
+## Vault Logging
+
+Throughout this action, log significant events to the vault session log. Read the session log path from `.smith/vault/.current-session`. If the file is missing or the vault is not initialized, skip all logging silently.
+
+Append entries using this format:
+
+```
+### [HH:MM:SS] /smith-audit <event>
+
+**User Request:**
+> <verbatim user message that triggered this action>
+
+**Synthesized Input:** <brief summary>
+**Outcome:** <what happened>
+**Findings:** <summary>
+**Systems affected:** <system IDs>
+```
+
+Log at these points:
+1. **On invocation** — which system(s) selected, full audit or specific sub-audit
+2. **After each sub-audit completes** — sub-audit name, finding count by severity (critical/high/medium/low)
+3. **After unified report generated** — path to report, total findings across all sub-audits
+4. **If action plan generated** — count of remediation items by priority
+
+## System Selection
+
+### If `$ARGUMENTS` contains `--all`:
+- Run audits across ALL systems (full-spectrum mode)
+- Reports go to individual system folders + a global summary at `specs/audits/<date>-full-spectrum.md`
+- Use subagents per system to manage context
+
+### If `$ARGUMENTS` contains a system identifier (e.g., `system-15`, `command-center`, `014`):
+- Match it to the correct system spec directory
+- Run all sub-audits on that system only
+
+### If `$ARGUMENTS` is empty:
+- Scan for all system spec directories:
+  ```bash
+  ls -d specs/system-*/spec.md specs/[0-9]*/spec.md 2>/dev/null
+  ```
+- Present a numbered list to the user:
+  ```
+  Which system would you like to audit?
+
+  1. system-00-config-isolation
+  2. system-01-core-infrastructure
+  3. system-03-email-archive-contact-graph
+  ...
+  15. system-15-command-center
+
+  Or type --all for a full-spectrum audit across all systems.
+  ```
+- Wait for user selection before proceeding.
+
+## System-to-Code Mapping
+
+Each system audit needs to know which code directories and files belong to it. Determine this by:
+
+1. **Reading the system's `spec.md`** — look for file paths, service names, directory references
+2. **Known mappings** (from CLAUDE.md Architecture section):
+   - `system-00-config-isolation` → `docker-compose.yml`, `.env`, `scripts/`
+   - `system-01-core-infrastructure` → `docker-compose.yml`, `scripts/`, infrastructure configs
+   - `system-02-ai-models-layer` → Ollama configs, model files
+   - `system-03-email-archive-contact-graph` → `services/email-pipeline/`, Qdrant collections, Neo4j schemas
+   - `system-04-personal-voice` → `services/voice-training/`
+   - `system-05-communication-triage` → `services/communication-triage/`, `services/command-center/routes/triage.js`
+   - `system-06-communication-learning-loop` → N8N workflows, training pipeline
+   - `system-09-meeting-intelligence` → meeting-related services
+   - `system-10-social-listening` → social signal services
+   - `system-13-trend-intelligence` → trend analysis services
+   - `system-15-command-center` → `services/command-center/` (full frontend + Express backend)
+3. **Fallback**: Grep the codebase for references to the system name/number
+
+## Documentation Sources
+
+Every sub-audit MUST also review these documentation sources for the target system:
+
+1. **Session logs**: `docs/sessions/*.md` — filter for sessions tagged with the system name/number. Check if decisions made in sessions are reflected in the current code.
+2. **System questions**: `specs/system-XX-*/questions.md` — check for unanswered questions (blank `**Answer:**` fields). Flag as unresolved decisions.
+3. **Pre-implementation questions**: `specs/questions/*.md` — check for questions related to the target system. Verify answered questions were implemented.
+4. **Feature specs**: `specs/[0-9]*-*/spec.md` — check for feature specs that reference the target system. Verify those features are implemented.
+
+## Ledger Context (Optional)
+
+If `.smith/vault/ledger/` exists and contains non-empty files, load relevant Ledger sections to inform this audit. If the directory is missing, empty, or unreadable, skip silently — the Ledger is purely additive and never required.
+
+1. Check: `ls .smith/vault/ledger/*.md 2>/dev/null`
+2. If files exist, read the following sections (higher-confidence entries first, truncate at ~2000 tokens per file):
+   - `.smith/vault/ledger/patterns.md` (audit-category entries)
+   - `.smith/vault/ledger/antipatterns.md`
+3. Use loaded patterns as additional context — look for known issues and successful approaches from past audits. The Ledger informs judgment, it does not override spec/plan/constitution.
+4. **Budget violation tracking**: If any Ledger file was truncated (entries were dropped to fit within the ~2000 token budget per file), increment `context_budget_violations` in `.smith/vault/ledger/.meta.json` by 1. If `.meta.json` does not exist, create it from the default template first. This signal tells the reconciliation system that the Ledger is too large for the configured budget.
+
+## Sub-Audit Orchestration
+
+For the selected system(s), launch sub-audits as subagents. Each sub-audit can run in parallel since they examine different aspects:
+
+1. **Requirements** (`smith-audit requirements`) — spec ↔ code ↔ UI alignment
+2. **Code Quality** (`smith-audit codequality`) — style, structure, complexity, duplication
+3. **Performance** (`smith-audit performance`) — API efficiency, query optimization, rendering
+4. **Security** (`smith-audit security`) — OWASP top 10, secrets, auth, dependencies
+5. **Accessibility** (`smith-audit accessibility`) — WCAG, keyboard nav, screen readers
+6. **UX** (`smith-audit ux`) — Playwright-driven UI testing, latency, responsiveness
+7. **Dependencies** (`smith-audit dependencies`) — outdated packages, CVEs, unused deps
+8. **Infrastructure** (`smith-audit infrastructure`) — Docker, health, configs, monitoring
+9. **Workflow** (`smith-audit workflow`) — open PRs, unmerged branches, incomplete tasks, stale work
+10. **SEO** (`smith-audit seo`) — Playwright-driven technical SEO audit via sitemap crawling (meta tags, headings, schema, performance, crawlability)
+11. **Feature** (`smith-audit feature`) — End-to-end deep audit of a single feature: data flow tracing, concurrency/race condition analysis, data integrity spot-checks, error handling gaps, and real-world output validation. Includes user interview phase.
+
+## Report Generation
+
+### Per-System Report
+After all sub-audits complete, generate a unified report at:
+```
+specs/system-XX-<name>/audits/<YYYY-MM-DD>-full.md
+```
+
+Structure:
+```markdown
+# Audit Report: [System Name]
+
+**Date**: YYYY-MM-DD
+**System**: [system identifier]
+**Auditor**: Claude Code (automated)
+
+## Executive Summary
+
+| Category | Critical | Warning | Info | Score |
+|----------|----------|---------|------|-------|
+| Requirements | 0 | 2 | 5 | 85/100 |
+| Code Quality | 1 | 3 | 8 | 72/100 |
+| Performance | 0 | 1 | 3 | 90/100 |
+| Security | 0 | 0 | 2 | 95/100 |
+| Accessibility | 2 | 4 | 1 | 60/100 |
+| UX | 0 | 1 | 2 | 88/100 |
+| Dependencies | 0 | 5 | 3 | 78/100 |
+| Infrastructure | 0 | 0 | 1 | 98/100 |
+| Workflow | 0 | 3 | 5 | 80/100 |
+| SEO | 0 | 4 | 6 | 82/100 |
+| **Overall** | **3** | **23** | **36** | **80/100** |
+
+## Unresolved Questions
+
+[List any questions.md entries with blank Answer fields for this system]
+
+## Critical Issues (Must Fix)
+
+[Ranked by severity]
+
+## Warnings (Should Fix)
+
+[Ranked by impact]
+
+## Informational (Nice to Have)
+
+[Lower priority improvements]
+
+## Documentation Gaps
+
+[Specs that don't match code, undocumented features, stale session decisions]
+
+## Detailed Sub-Audit Reports
+
+See individual reports:
+- [Requirements](audits/YYYY-MM-DD-requirements.md)
+- [Code Quality](audits/YYYY-MM-DD-codequality.md)
+- ...
+```
+
+### Full-Spectrum Report (--all mode)
+Generate a global summary at:
+```
+specs/audits/<YYYY-MM-DD>-full-spectrum.md
+```
+
+With per-system scores and cross-system issues (e.g., inconsistent patterns between services, shared dependency conflicts).
+
+## PDF Report Generation
+
+After the markdown report is written, generate a professional PDF version for client delivery.
+
+### Setup
+
+1. Copy the canonical PDF generator into the audit output directory:
+   ```bash
+   cp ~/.claude/skills/smith/scripts/audit-pdf-generator.mjs specs/audits/audit-pdf-generator.mjs
+   ```
+2. Ensure puppeteer is installed:
+   ```bash
+   cd specs/audits && ls node_modules/puppeteer 2>/dev/null || (npm init -y --quiet 2>/dev/null && npm install puppeteer --save --quiet)
+   ```
+
+### Execution
+
+```bash
+cd specs/audits && node audit-pdf-generator.mjs <YYYY-MM-DD>-full-spectrum.md
+```
+
+The script auto-detects the report type (full-spectrum, SEO, or sub-audit) from the H1 heading and generates appropriate cover page styling.
+
+### Output
+
+The PDF is written alongside the markdown file (e.g., `specs/audits/2026-03-30-full-spectrum.pdf`). Mention both the `.md` and `.pdf` paths in the final output to the user.
+
+---
+
+## Key Rules
+
+- Always create the `audits/` directory inside the system spec folder before writing reports
+- Each sub-audit runs as a subagent to preserve context
+- Sub-audits can run in parallel (they're read-only)
+- Never modify code during an audit — audits are read-only and produce reports only
+- Score each category 0-100 based on findings (critical = -20, warning = -5, info = -1)
+- Flag any `questions.md` with unanswered questions as a documentation gap

--- a/skills/smith-bank/SKILL.md
+++ b/skills/smith-bank/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: smith-bank
 description: Captures ideas mid-conversation and stores them in the vault for later processing. Use when the user wants to save an idea, park a thought, or come back to something later. Supports listing, processing, editing, and prioritizing banked ideas.
-argument-hint: [list|process|edit|remove|prioritize] [<id>] [--priority <level>] [--system <id>]
+argument-hint: "[list|process|edit|remove|prioritize] [<id>] [--priority <level>] [--system <id>]"
 ---
 
 # Smith Idea Bank

--- a/skills/smith-explore/SKILL.md
+++ b/skills/smith-explore/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: smith-explore
 description: Pre-change exploration — audits codebase for system-wide impacts, identifies touch points, and surfaces conflicts before proceeding with smith-new or other workflows.
-argument-hint: [<feature-description>] [--scope skills|hooks|configs|all] [--deep]
+argument-hint: "[<feature-description>] [--scope skills|hooks|configs|all] [--deep]"
 ---
 
 # Smith Explore — Pre-Change Impact Analysis

--- a/skills/smith-ledger/SKILL.md
+++ b/skills/smith-ledger/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: smith-ledger
 description: Browse, search, and manage the Smith Ledger — the accumulated patterns, antipatterns, tool preferences, and edge cases learned from past workflows. Use to review what Smith has learned, search for relevant patterns, prune outdated entries, or inspect the Ledger's evolution over time.
-argument-hint: [list|show|search|prune|promote|demote|export|reset] [<title-or-query>] [--category <cat>] [--confidence <level>] [--file <filename>] [--auto]
+argument-hint: "[list|show|search|prune|promote|demote|export|reset] [<title-or-query>] [--category <cat>] [--confidence <level>] [--file <filename>] [--auto]"
 ---
 
 # Smith Ledger — Knowledge Base Management

--- a/skills/smith-migrate-specs/SKILL.md
+++ b/skills/smith-migrate-specs/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: smith-migrate-specs
 description: One-time migration of existing flat spec folders into the system-based hierarchy under .specify/systems/.
-argument-hint: [--dry-run] [--all]
+argument-hint: "[--dry-run] [--all]"
 ---
 
 # Smith Spec Migration

--- a/skills/smith-report/SKILL.md
+++ b/skills/smith-report/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: smith-report
 description: Generate client-facing project reports from vault data — progress updates, decision logs, spec changelogs, or full audit reports.
-argument-hint: [--range week|month|YYYY-MM-DD:YYYY-MM-DD] [--type progress|decisions|specs|full] [--project <name>]
+argument-hint: "[--range week|month|YYYY-MM-DD:YYYY-MM-DD] [--type progress|decisions|specs|full] [--project <name>]"
 ---
 
 # Smith Client Report Generator

--- a/skills/smith-todo/SKILL.md
+++ b/skills/smith-todo/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: smith-todo
 description: Manage daily todo lists stored in the vault. Supports listing, adding, completing, deferring, editing, removing items, reviewing past days, weekly overview, and completion stats.
-argument-hint: [list|add|done|defer|remove|edit|review|week|stats] [<id-or-title>] [--date YYYY-MM-DD] [--to YYYY-MM-DD]
+argument-hint: "[list|add|done|defer|remove|edit|review|week|stats] [<id-or-title>] [--date YYYY-MM-DD] [--to YYYY-MM-DD]"
 ---
 
 # Smith Todo

--- a/skills/smith-vault/SKILL.md
+++ b/skills/smith-vault/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: smith-vault
 description: Browse vault contents — session logs, sub-agent memory, and queue status.
-argument-hint: [sessions|agents|queue|status|projects] [<name>]
+argument-hint: "[sessions|agents|queue|status|projects] [<name>]"
 ---
 
 # Smith Vault Browser

--- a/skills/smith/SKILL.md
+++ b/skills/smith/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: smith.init
+name: smith
 description: Initialize SpecKit on a new or existing project — scans the codebase, interviews you about project details, and generates CLAUDE.md, constitution.md, and the full .specify/ scaffolding with commands and agents.
 argument-hint: [--preset flask-react|fastapi-next|cli-python|express-react]
 ---


### PR DESCRIPTION
## Summary

Makes the Smith repo installable via `npx skills add attck/smith` by fixing four distribution gaps.

- **YAML quoting fix for 7 skills.** `argument-hint:` values that started with `[` and contained multiple space-separated bracketed groups (e.g. `[list|process|...] [<id>] [--priority <level>]`) were silently rejected by the `skills` CLI parser. Wrapping them in double quotes makes YAML treat them as plain string scalars. The string content displayed to users is identical; only the parse path changes. Root cause and evidence in [`specs/013-distribution-readiness/research.md`](specs/013-distribution-readiness/research.md) (local; specs/ is gitignored).
- **`smith.init` → `smith` rename.** Frontmatter `name:` in `skills/smith/SKILL.md` now matches its folder name. **Breaking:** `/smith.init` no longer matches; use `/smith`.
- **`smith-audit` ported from `~/.claude/skills/`.** Brings the public distribution to 26 skills. `smith-design` and `smith-timesheet` remain agency-package-only by design and are not ported.
- **README `Getting Started` section.** Adds `npx skills add attck/smith` as the primary skills-only path, plus update command and a one-line verification tip. The existing curl installer remains as the full skills+hooks+scheduler path.

Before this PR: `npx skills add . --list` detected 18 of 25 skills.
After this PR: `npx skills add . --list` detects all 26.

## Test plan

- [ ] `npx skills add . --list` from the repo root shows 26 skills (including `smith-audit` and `smith`, not `smith.init`)
- [ ] `grep -c "npx skills add attck/smith" README.md` returns `>= 1`
- [ ] `grep "^name: smith$" skills/smith/SKILL.md` matches; `grep "^name: smith.init" skills/smith/SKILL.md` does not
- [ ] Claude Code still loads every skill locally (no regressions from the quoting change) — confirmed via skill list in a fresh session
- [ ] CHANGELOG `[Unreleased]` section documents: `npx skills add` install, smith-audit addition, the 7-skill YAML quoting fix, and the `smith.init → smith` rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)