### PR TITLE
fix: correct install command org slug (attck → ATTCKDigital)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Install via `npx skills add attck/smith` — new distribution path that copies all 26 skills into `~/.claude/skills/` without requiring the curl installer. Skills-only; hooks and scheduler still require the bundled installer.
+- Install via `npx skills add ATTCKDigital/smith` — new distribution path that copies all 26 skills into `~/.claude/skills/` without requiring the curl installer. Skills-only; hooks and scheduler still require the bundled installer.
 - New skill in the public distribution: `/smith-audit` — cross-system audit orchestrator. Previously only in the agency-internal skill set; now shipped with the public Smith distribution.
 - New skill: `/smith-explore` — pre-change impact analysis for features touching core infrastructure
 - New hook: `metrics-tracker.sh` — PostToolUse hook that captures character counts for token estimation

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The outcome: you talk to Claude about what you want to build, Smith handles the 
 ### Install via the `skills` CLI (skills only)
 
 ```bash
-npx skills add attck/smith
+npx skills add ATTCKDigital/smith
 ```
 
 This is the fastest path — it copies all 26 Smith skills into `~/.claude/skills/` and nothing else. Use this if you only want the Smith workflow commands.


### PR DESCRIPTION
## Summary

- PR #13 shipped the install command as `npx skills add attck/smith` but the GitHub org is `ATTCKDigital`. `github.com/attck/smith` returns 404.
- Replaces both occurrences (README.md line 29, CHANGELOG.md line 12) with the correct slug.
- Verified: `npx skills add ATTCKDigital/smith --list` from a fresh `/tmp` directory discovers all 26 skills.

## Test plan

- [ ] `grep -c "attck/smith" README.md CHANGELOG.md` returns 0
- [ ] `grep -c "ATTCKDigital/smith" README.md CHANGELOG.md` returns at least 2
- [ ] From a scratch directory: `npx skills add ATTCKDigital/smith --list` returns 26 skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)