### PR TITLE
fix(smith-index): resolve parser modules from flat install layout

### DIFF
--- a/scripts/smith-index/run.py
+++ b/scripts/smith-index/run.py
@@ -83,17 +83,41 @@ REPO_ROOT = THIS_DIR.parent.parent  # smith-manifest-system root
 PARSER_DIR_REPO = REPO_ROOT / "scripts" / "parsers"
 PARSER_DIR_GLOBAL = Path.home() / ".smith" / "scripts"
 
-# Add path-resolver location to sys.path so we can `import path_resolver`.
+# Add parser locations to sys.path so we can `import path_resolver` etc.
+# Prefer the dev-tree layout (PARSER_DIR_REPO) for in-tree runs, then fall
+# back to the production install layout (PARSER_DIR_GLOBAL = ~/.smith/scripts/,
+# flat — that's how install-parsers.sh stages them). This dual-layout matters
+# because when run.py is installed to ~/.smith/scripts/smith-index/run.py,
+# REPO_ROOT computes to ~/.smith/ and PARSER_DIR_REPO points at
+# ~/.smith/scripts/parsers/ — which doesn't exist in the flat install layout.
 sys.path.insert(0, str(PARSER_DIR_REPO))
+sys.path.insert(0, str(PARSER_DIR_GLOBAL))
+
+
+def _resolve_parser_module_path(filename: str) -> Path | None:
+    """Return the first existing path for a parser-layer module file.
+
+    Tries PARSER_DIR_REPO (dev-tree, scripts/parsers/<name>) first,
+    falls back to PARSER_DIR_GLOBAL (production install, ~/.smith/scripts/<name>).
+    Returns None if neither exists — callers degrade gracefully.
+    """
+    for candidate in (PARSER_DIR_REPO / filename, PARSER_DIR_GLOBAL / filename):
+        if candidate.is_file():
+            return candidate
+    return None
+
+
 try:
     import importlib.util as _ilu
 
-    _spec = _ilu.spec_from_file_location(
-        "path_resolver", PARSER_DIR_REPO / "path-resolver.py"
-    )
-    if _spec and _spec.loader:
-        path_resolver = _ilu.module_from_spec(_spec)
-        _spec.loader.exec_module(path_resolver)  # type: ignore[attr-defined]
+    _pr_path = _resolve_parser_module_path("path-resolver.py")
+    if _pr_path:
+        _spec = _ilu.spec_from_file_location("path_resolver", _pr_path)
+        if _spec and _spec.loader:
+            path_resolver = _ilu.module_from_spec(_spec)
+            _spec.loader.exec_module(path_resolver)  # type: ignore[attr-defined]
+        else:
+            path_resolver = None  # type: ignore[assignment]
     else:
         path_resolver = None  # type: ignore[assignment]
 except Exception:
@@ -103,14 +127,16 @@ except Exception:
 # descriptions never call it. `parse_existing_descriptions` is re-exported
 # here so the save hook can import a single name from run.py.
 try:
-    _md_spec = _ilu.spec_from_file_location(
-        "meta_describe", PARSER_DIR_REPO / "meta_describe.py"
-    )
-    if _md_spec and _md_spec.loader:
-        _meta_describe = _ilu.module_from_spec(_md_spec)
-        # Python 3.14 dataclass needs the module in sys.modules during exec.
-        sys.modules["meta_describe"] = _meta_describe
-        _md_spec.loader.exec_module(_meta_describe)  # type: ignore[attr-defined]
+    _md_path = _resolve_parser_module_path("meta_describe.py")
+    if _md_path:
+        _md_spec = _ilu.spec_from_file_location("meta_describe", _md_path)
+        if _md_spec and _md_spec.loader:
+            _meta_describe = _ilu.module_from_spec(_md_spec)
+            # Python 3.14 dataclass needs the module in sys.modules during exec.
+            sys.modules["meta_describe"] = _meta_describe
+            _md_spec.loader.exec_module(_meta_describe)  # type: ignore[attr-defined]
+        else:
+            _meta_describe = None  # type: ignore[assignment]
     else:
         _meta_describe = None  # type: ignore[assignment]
 except Exception:

--- a/tests/skills/test_smith_index_global_install_layout.py
+++ b/tests/skills/test_smith_index_global_install_layout.py
@@ -1,0 +1,170 @@
+"""Regression test: /smith-index runtime works against the FLAT production
+install layout.
+
+The bug this guards against: scripts/smith-index/run.py computes
+`PARSER_DIR_REPO = REPO_ROOT / "scripts" / "parsers"`, where REPO_ROOT is
+`Path(__file__).resolve().parent.parent.parent`. In the dev-tree layout
+(running from a smith-repo clone), that resolves to
+`<clone>/scripts/parsers/` and works. But when run.py is installed
+globally at `~/.smith/scripts/smith-index/run.py`, REPO_ROOT computes to
+`~/.smith/` and PARSER_DIR_REPO points at `~/.smith/scripts/parsers/` —
+which does NOT exist in the install layout because install-parsers.sh
+stages parsers FLAT at `~/.smith/scripts/` (no `parsers/` subdir, which is
+the correct install convention).
+
+Pre-fix symptom: `path_resolver = None` after run.py imports → tier-1 of
+the path resolver never fires → projects with declared `.specify/systems/`
+get bucketed by the heuristic instead.
+
+Post-fix behavior: run.py tries `PARSER_DIR_REPO/<name>` first (dev-tree)
+and falls back to `PARSER_DIR_GLOBAL/<name>` (= `~/.smith/scripts/<name>`,
+flat). This test exercises that fallback path.
+
+Run:
+    python3 tests/skills/test_smith_index_global_install_layout.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parent.parent
+RUN_PY = REPO / "scripts" / "smith-index" / "run.py"
+PARSERS_DIR = REPO / "scripts" / "parsers"
+
+
+def _load_run_py_with_home(fake_home: Path):
+    """Load run.py with HOME pointed at a tempdir mimicking the install layout."""
+    original_home = os.environ.get("HOME")
+    os.environ["HOME"] = str(fake_home)
+    # Force fresh imports so PARSER_DIR_GLOBAL re-resolves against the fake HOME.
+    for name in ("path_resolver", "meta_describe", "run"):
+        sys.modules.pop(name, None)
+    try:
+        spec = importlib.util.spec_from_file_location("run", RUN_PY)
+        if spec is None or spec.loader is None:
+            raise RuntimeError("could not load run.py")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        if original_home is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = original_home
+
+
+class GlobalInstallLayoutTests(unittest.TestCase):
+    """run.py must resolve parser modules from the flat ~/.smith/scripts/
+    layout when the dev-tree layout is absent."""
+
+    def _stage_flat_install(self, fake_home: Path) -> Path:
+        """Mimic install-parsers.sh: stage parsers FLAT at <home>/.smith/scripts/.
+
+        Also stages run.py inside the install location so its REPO_ROOT
+        resolves to <home>/.smith/ — the exact case that broke pre-fix.
+        Returns the directory where run.py was staged.
+        """
+        scripts_dir = fake_home / ".smith" / "scripts"
+        scripts_dir.mkdir(parents=True, exist_ok=True)
+        # Flat install — no parsers/ subdir, matching install-parsers.sh behavior.
+        shutil.copy(PARSERS_DIR / "path-resolver.py", scripts_dir / "path-resolver.py")
+        shutil.copy(PARSERS_DIR / "meta_describe.py", scripts_dir / "meta_describe.py")
+        shutil.copy(PARSERS_DIR / "parse-python.py", scripts_dir / "parse-python.py")
+        shutil.copy(PARSERS_DIR / "parse-js.js", scripts_dir / "parse-js.js")
+        # Stage run.py inside the install location so REPO_ROOT = <home>/.smith/.
+        install_run_dir = scripts_dir / "smith-index"
+        install_run_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy(RUN_PY, install_run_dir / "run.py")
+        return install_run_dir
+
+    def test_flat_install_layout_resolves_path_resolver(self):
+        """Pre-fix this fails — PARSER_DIR_REPO points at ~/.smith/scripts/parsers/
+        which doesn't exist, and the loader has no fallback. Post-fix it
+        resolves via PARSER_DIR_GLOBAL."""
+        with tempfile.TemporaryDirectory(prefix="smith-bugfix-") as tmp:
+            fake_home = Path(tmp)
+            install_run_dir = self._stage_flat_install(fake_home)
+
+            # Load the INSTALLED copy of run.py so REPO_ROOT == ~/.smith/.
+            original_home = os.environ.get("HOME")
+            os.environ["HOME"] = str(fake_home)
+            for name in ("path_resolver", "meta_describe", "run"):
+                sys.modules.pop(name, None)
+            try:
+                spec = importlib.util.spec_from_file_location(
+                    "run", install_run_dir / "run.py"
+                )
+                self.assertIsNotNone(spec)
+                self.assertIsNotNone(spec.loader)
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+
+                self.assertIsNotNone(
+                    module.path_resolver,
+                    "path_resolver must load from PARSER_DIR_GLOBAL "
+                    "(~/.smith/scripts/) when PARSER_DIR_REPO has no parsers/ subdir",
+                )
+                self.assertTrue(
+                    hasattr(module.path_resolver, "resolve"),
+                    "path_resolver module must expose resolve()",
+                )
+            finally:
+                if original_home is None:
+                    os.environ.pop("HOME", None)
+                else:
+                    os.environ["HOME"] = original_home
+
+    def test_flat_install_layout_resolves_meta_describe(self):
+        """Same fallback applies to meta_describe loading."""
+        with tempfile.TemporaryDirectory(prefix="smith-bugfix-") as tmp:
+            fake_home = Path(tmp)
+            install_run_dir = self._stage_flat_install(fake_home)
+
+            original_home = os.environ.get("HOME")
+            os.environ["HOME"] = str(fake_home)
+            for name in ("path_resolver", "meta_describe", "run"):
+                sys.modules.pop(name, None)
+            try:
+                spec = importlib.util.spec_from_file_location(
+                    "run", install_run_dir / "run.py"
+                )
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+
+                self.assertIsNotNone(
+                    module._meta_describe,
+                    "meta_describe must load from PARSER_DIR_GLOBAL when "
+                    "PARSER_DIR_REPO has no parsers/ subdir",
+                )
+            finally:
+                if original_home is None:
+                    os.environ.pop("HOME", None)
+                else:
+                    os.environ["HOME"] = original_home
+
+    def test_dev_tree_layout_still_works(self):
+        """Regression check: the dev-tree path (scripts/parsers/) must still
+        be preferred when present — the fallback should not break the
+        existing happy path."""
+        # Load run.py from its actual dev-tree location; PARSER_DIR_REPO is
+        # <repo>/scripts/parsers/ which exists.
+        for name in ("path_resolver", "meta_describe", "run"):
+            sys.modules.pop(name, None)
+        spec = importlib.util.spec_from_file_location("run", RUN_PY)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        self.assertIsNotNone(module.path_resolver)
+        self.assertIsNotNone(module._meta_describe)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- `/smith-index` was silently degrading to v1 heuristic on globally-installed copies — tier-1 resolver and meta_describe never loaded because run.py's module loader assumed a dev-tree `scripts/parsers/` subdir that doesn't exist in the flat install layout
- Added a `_resolve_parser_module_path()` fallback helper that tries `PARSER_DIR_REPO` first then falls back to `PARSER_DIR_GLOBAL` (= `~/.smith/scripts/`, flat)
- Regression test exercises the install layout end-to-end (stages parsers + run.py in a tempdir mimicking `~/.smith/scripts/`, sets HOME, asserts both modules load)

## What was broken
`scripts/smith-index/run.py` line 83 computed `PARSER_DIR_REPO = REPO_ROOT / "scripts" / "parsers"`, where `REPO_ROOT = THIS_DIR.parent.parent`. In dev runs (from a smith-repo clone), this resolves to `<clone>/scripts/parsers/` and works. But when `scripts/install.sh` stages run.py to `~/.smith/scripts/smith-index/run.py`, `REPO_ROOT` resolves to `~/.smith/`, so `PARSER_DIR_REPO` points at `~/.smith/scripts/parsers/` — which **doesn't exist**. `scripts/install-parsers.sh` correctly stages parsers FLAT at `~/.smith/scripts/path-resolver.py` (with no `parsers/` subdir, which is the right install convention).

Result: `path_resolver` and `_meta_describe` both silently set to `None` in production-installed environments. Tier-1 of the resolver (`.specify/systems/` `paths:` frontmatter — the whole point of the v2 work in PR #21) never fired. armory's first v2 `/smith-index` run produced 7-8 heuristic buckets instead of 18 declared-system buckets specifically because of this.

## What changed
- `scripts/smith-index/run.py`: new `_resolve_parser_module_path(filename)` helper that tries `PARSER_DIR_REPO/<name>` first then `PARSER_DIR_GLOBAL/<name>`. Applied to both `path_resolver` and `_meta_describe` loading blocks. Added `PARSER_DIR_GLOBAL` to `sys.path` alongside `PARSER_DIR_REPO`. Net change: ~30 LOC, no behavior changes for dev-tree runs.
- `tests/skills/test_smith_index_global_install_layout.py` (NEW, 3 tests): stages a flat install in a tempdir with run.py inside it, sets HOME, imports run.py via importlib.spec, asserts `path_resolver` and `_meta_describe` are non-None. Plus a regression-counter test that confirms the dev-tree happy path still works post-fix.

## Why this approach
- Fix is in `run.py`, not `install-parsers.sh`, because flat install IS the correct convention — `install-parsers.sh` matches how `parser-lib.sh resolve_parser` looks things up at runtime, the global install pattern in install.sh, and the install path users expect. The bug is run.py assuming a dev-tree subdir.
- The dual sys.path entries + dual-fallback module loader cover both layouts cleanly with zero behavior change for in-tree runs.
- No source modification beyond run.py — keeps the blast radius tiny.

## Test plan
- [x] New regression test (3 cases): flat install resolves both modules + dev-tree still works
- [x] Full v2 regression sweep: resolver tier-1 (11 tests), meta_describe (16), stable-id Python (13), save-hook preservation (12) — all green
- [ ] Post-merge: pull main, run `bash scripts/install.sh -y` on local machine, re-run `/smith-index` on armory, verify 18 system buckets appear (not 7-8)

## Related
- v2 manifest system spec/plan: `specs/20-manifest-fixes/`
- Original v2 merge: PR #21 (5aead0b)

🤖 Generated with [Claude Code](https://claude.com/claude-code)