### PR TITLE
fix: workflow-summary --totals-only reports zeros after session rollover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`workflow-summary --totals-only` reported all zeros after a session-log
+  rollover** (see `specs/debug/debug-2026-06-03-workflow-summary-zeros.md`).
+  When a long/multi-day conversation rolled the session log mid-workflow,
+  `.smith/vault/.current-session` repointed at a fresh, markerless file;
+  `find_invocation()` returned `None` and the lib silently emitted
+  `Token Usage: 0 / $0.00 / 0s` as if real. Three coordinated fixes:
+  - **Session-rollover resilience.** `hooks/workflow-summary.sh` now resolves
+    the session file by precedence: (a) an explicit `--session <path>` CLI
+    flag, (b) the `session_log:` field of an active-workflow marker
+    (`.smith/vault/active-workflows/*.yaml`; when several exist, the one whose
+    `branch:` matches the current git branch), (c) the existing
+    `.current-session` fallback (fully backwards-compatible).
+  - **Loud degenerate path.** When no `/smith-(new|bugfix|debug)` invocation
+    marker is found, `hooks/workflow_summary_lib.py` now prints a stderr
+    diagnostic naming the file actually read, emits explicit
+    `Token Usage: n/a (no workflow invocation found)` / `Est. cost: n/a` /
+    `Active duration: n/a` lines (same 3-line shape), and exits non-zero — so
+    callers never paste misleading zeros. A genuine zero-usage workflow (marker
+    present, truly 0 tokens) still renders real zeros and is distinguishable.
+  - **Marker writers + call sites.** `/smith-new`, `/smith-bugfix`, and
+    `/smith-debug` now capture the workflow's session log at start, write it as
+    `session_log:` into the active-workflow marker, and pass `--session
+    "$SESSION"` to the end-of-workflow `--totals-only` call.
 - **Hash-cache bug from PR #21** — v2 wrote
   `Described-Against-Hash:` as `sha256(full_source)` but compared it
   against `sha256_first_4kb(file)` at the cache-check site. Cache

--- a/hooks/workflow-summary.sh
+++ b/hooks/workflow-summary.sh
@@ -18,6 +18,11 @@
 #   Skills invoke this to include totals inline in their final chat message
 #   BEFORE Stop fires (Stop-hook stdout doesn't reach the preceding chat bubble).
 #
+#   Optional flag: --session <path> — read totals from <path> instead of the
+#   resolved default. Takes precedence over every other source. Skills capture
+#   their workflow's session-log path at start and pass it here so totals are
+#   computed against the correct file even after a mid-workflow log rollover.
+#
 # Computations are implemented in hooks/workflow_summary_lib.py. This script is
 # a thin wrapper that enforces gates, sets env vars, and hands off to Python.
 #
@@ -36,9 +41,33 @@
 set -euo pipefail
 
 TOTALS_ONLY=0
-if [ "${1:-}" = "--totals-only" ]; then
-    TOTALS_ONLY=1
-else
+EXPLICIT_SESSION=""
+# Argument parsing. Supported forms:
+#   workflow-summary.sh                      (Stop-hook mode)
+#   workflow-summary.sh --totals-only        (chat-block mode)
+#   workflow-summary.sh --totals-only --session <path>
+#   workflow-summary.sh --session <path> --totals-only
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --totals-only)
+            TOTALS_ONLY=1
+            shift
+            ;;
+        --session)
+            EXPLICIT_SESSION="${2:-}"
+            shift 2 2>/dev/null || shift
+            ;;
+        --session=*)
+            EXPLICIT_SESSION="${1#--session=}"
+            shift
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+if [ "$TOTALS_ONLY" = "0" ]; then
     # Stop-hook path: consume stdin (Claude Code pipes JSON). In --totals-only
     # mode we skip this so manual callers don't have to redirect /dev/null.
     INPUT=$(cat)
@@ -46,14 +75,85 @@ fi
 
 VAULT_DIR="${CLAUDE_PROJECT_DIR:-.}/.smith/vault"
 CURRENT_SESSION_PTR="$VAULT_DIR/.current-session"
-
-# Silent exit if vault not initialized
-[ -f "$CURRENT_SESSION_PTR" ] || exit 0
-
-SESSION_FILE=$(cat "$CURRENT_SESSION_PTR")
-[ -f "$SESSION_FILE" ] || exit 0
-
 PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+
+# ---------------------------------------------------------------------------
+# resolve_session_file — choose which session log to read for totals.
+#
+# Precedence (highest first), so that totals survive a mid-workflow session
+# rollover that repoints .current-session at a fresh, markerless file:
+#   (a) --session <path>  — explicit CLI override; always wins if it exists.
+#   (b) the `session_log:` field of an active-workflow marker:
+#         .smith/vault/active-workflows/*.yaml
+#       When exactly one marker carries a session_log, use it. When several do,
+#       prefer the one whose `branch:` matches the current git branch; if none
+#       match, fall through to (c).
+#   (c) .smith/vault/.current-session — the historical default (fully
+#       backwards-compatible fallback).
+# Prints the resolved path to stdout, or nothing if none resolve.
+# ---------------------------------------------------------------------------
+resolve_session_file() {
+    # (a) explicit override
+    if [ -n "$EXPLICIT_SESSION" ]; then
+        if [ -f "$EXPLICIT_SESSION" ]; then
+            printf '%s' "$EXPLICIT_SESSION"
+            return 0
+        fi
+        # An explicit path that doesn't exist still wins (caller intent); the
+        # Python layer will report it as not-found rather than silently using
+        # the wrong file.
+        printf '%s' "$EXPLICIT_SESSION"
+        return 0
+    fi
+
+    # (b) active-workflow marker(s) carrying session_log:
+    local wf_dir="$VAULT_DIR/active-workflows"
+    if [ -d "$wf_dir" ]; then
+        local cur_branch
+        cur_branch=$(cd "$PROJECT_ROOT" 2>/dev/null && git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+        local only_log="" only_count=0 branch_log=""
+        local marker log mbranch
+        for marker in "$wf_dir"/*.yaml; do
+            [ -f "$marker" ] || continue
+            log=$(awk -F': *' '/^[[:space:]]*session_log:/ {sub(/^[^:]*:[[:space:]]*/, ""); gsub(/^"|"$/, ""); print; exit}' "$marker")
+            [ -n "$log" ] || continue
+            only_count=$((only_count + 1))
+            only_log="$log"
+            mbranch=$(awk -F': *' '/^[[:space:]]*branch:/ {sub(/^[^:]*:[[:space:]]*/, ""); gsub(/^"|"$/, ""); print; exit}' "$marker")
+            if [ -n "$cur_branch" ] && [ "$mbranch" = "$cur_branch" ]; then
+                branch_log="$log"
+            fi
+        done
+        if [ "$only_count" -eq 1 ] && [ -n "$only_log" ]; then
+            printf '%s' "$only_log"
+            return 0
+        fi
+        if [ "$only_count" -gt 1 ] && [ -n "$branch_log" ]; then
+            printf '%s' "$branch_log"
+            return 0
+        fi
+        # multiple markers but none match current branch → fall through to (c)
+    fi
+
+    # (c) backwards-compatible fallback
+    if [ -f "$CURRENT_SESSION_PTR" ]; then
+        cat "$CURRENT_SESSION_PTR"
+        return 0
+    fi
+    return 1
+}
+
+SESSION_FILE=$(resolve_session_file)
+
+# Silent exit if nothing resolved (vault not initialized and no override).
+[ -n "$SESSION_FILE" ] || exit 0
+
+# In Stop-hook mode the file must exist (we read gates from it and append to
+# it). In --totals-only mode we let a missing file fall through to Python so it
+# can emit the loud not-found diagnostic rather than silently exiting.
+if [ "$TOTALS_ONLY" = "0" ] && [ ! -f "$SESSION_FILE" ]; then
+    exit 0
+fi
 
 if [ "$TOTALS_ONLY" = "0" ]; then
     # Guard: already emitted?

--- a/hooks/workflow_summary_lib.py
+++ b/hooks/workflow_summary_lib.py
@@ -508,6 +508,23 @@ def render_chat_block(totals: Dict[str, Any]) -> str:
     )
 
 
+def render_no_marker_block() -> str:
+    """Three-line block for the no-invocation-marker case (S1 / FIX 2).
+
+    Keeps the same 3-line shape callers expect, but every value is an explicit
+    'n/a (no workflow invocation found)' so nothing reads as a genuine $0.00 /
+    0s result. Pairs with a non-zero exit code and a stderr diagnostic so a
+    caller can detect the condition programmatically. This is distinct from a
+    real zero-usage workflow, which DOES have an invocation marker and renders
+    via render_chat_block with literal zeros.
+    """
+    return (
+        "Token Usage: n/a (no workflow invocation found)\n"
+        "Est. cost: n/a\n"
+        "Active duration: n/a\n"
+    )
+
+
 def render_audit_block(
     totals: Dict[str, Any],
     files_changed: List[str],
@@ -828,6 +845,17 @@ def main() -> int:
     totals_only = os.environ.get("TOTALS_ONLY") == "1"
 
     if not session_file or not os.path.isfile(session_file):
+        # Missing session file. In Stop-hook mode this is a silent no-op (the
+        # wrapper already guards it). In --totals-only mode, be loud rather than
+        # print misleading zeros (FIX 2): tell the caller exactly which path we
+        # tried to read, and exit non-zero.
+        if totals_only:
+            sys.stderr.write(
+                "workflow-summary: session file not found: "
+                f"{session_file or '(none resolved)'}\n"
+            )
+            sys.stdout.write(render_no_marker_block())
+            return 3
         return 0
 
     content = _read(session_file)
@@ -836,34 +864,19 @@ def main() -> int:
     start_utc, end_utc = resolve_workflow_window(session_file, content)
     invoke = find_invocation(content)
     if invoke is None:
-        # Without an invocation we can't produce a meaningful summary.
+        # Without an invocation marker we can't produce a meaningful summary.
+        # FIX 2 (S1): make this LOUD instead of emitting plausible-looking zeros.
+        # Emit a stderr diagnostic naming the file actually read, print explicit
+        # n/a lines (same 3-line shape), and exit non-zero so callers detect it.
+        # A genuine zero-usage workflow still has a marker and does NOT hit this
+        # branch — only the no-marker case prints n/a.
         if totals_only:
-            # Still emit the 3-line block in the degenerate form.
-            degenerate = {
-                "combined_normalized": 0,
-                "combined_usd": 0.0,
-                "combined_raw_components": {
-                    "input_tokens": 0,
-                    "output_tokens": 0,
-                    "cache_creation_input_tokens": 0,
-                    "cache_read_input_tokens": 0,
-                },
-                "combined_raw_total": 0,
-                "parent_usage": None,
-                "parent_model": None,
-                "parent_tool_calls": 0,
-                "parent_active_duration_s": 0,
-                "parent_normalized": 0,
-                "parent_usd": None,
-                "subagent_rows": [],
-                "total_elapsed_s": 0,
-                "active_duration_s": 0,
-                "n_total_sessions": 0,
-                "n_priced_sessions": 0,
-                "unknown_model_ids": [],
-                "pricing_missing": False,
-            }
-            sys.stdout.write(render_chat_block(degenerate))
+            sys.stderr.write(
+                "workflow-summary: no /smith-(new|bugfix|debug) invocation "
+                f"marker found in {session_file}\n"
+            )
+            sys.stdout.write(render_no_marker_block())
+            return 2
         return 0
     started_hms, workflow_type = invoke
 

--- a/skills/smith-bugfix/SKILL.md
+++ b/skills/smith-bugfix/SKILL.md
@@ -91,12 +91,16 @@ Every bugfix always runs in an isolated git worktree branched from the configure
 2. **Activate workflow tracking** — create a per-branch file in `.smith/vault/active-workflows/` in the **primary repo** (not the worktree, which doesn't exist yet):
    ```bash
    SAFE_BRANCH=$(echo "$BRANCH" | sed 's/[^a-zA-Z0-9._-]/-/g')
+   # Capture the workflow's session log NOW, at the start, so end-of-workflow
+   # totals read the correct file even if the session log rolls over later.
+   SESSION=$(cat .smith/vault/.current-session 2>/dev/null || echo "")
    mkdir -p .smith/vault/active-workflows
    cat > .smith/vault/active-workflows/${SAFE_BRANCH}.yaml << EOF
    workflow: smith-bugfix
    feature: $SLUG
    branch: $BRANCH
    worktree: $WORKTREE_PATH
+   session_log: $SESSION
    started: $(date -u +"%Y-%m-%dT%H:%M:%S")
    EOF
    ```
@@ -368,7 +372,14 @@ Skip if no Docker services were touched.
 
 ### 8.2 Summary
 
-Emit a final chat message to the user that starts with "Bugfix complete. Here's the summary:" (or equivalent for the fix). Include any bugfix-specific notes (test results, services rebuilt, worktree path if preserved on failure). At the bottom, run `bash hooks/workflow-summary.sh --totals-only` (from either the primary repo or the worktree — both work) and paste the two lines it prints (`Total tokens used: ~<n>` and `Total duration: <d>`) verbatim — do this BEFORE the Workflow Cleanup step below.
+Emit a final chat message to the user that starts with "Bugfix complete. Here's the summary:" (or equivalent for the fix). Include any bugfix-specific notes (test results, services rebuilt, worktree path if preserved on failure). At the bottom, run the totals command and paste the lines it prints verbatim — do this BEFORE the Workflow Cleanup step below. Pass the workflow's own session log via `--session` so totals are computed against the correct file even if the session log rolled over mid-workflow:
+```bash
+# $SESSION was captured at workflow start (Phase 1 step 2). Fall back to the
+# marker's session_log field, then to .current-session, if not in scope here.
+SESSION="${SESSION:-$(cat .smith/vault/.current-session 2>/dev/null)}"
+bash hooks/workflow-summary.sh --totals-only --session "$SESSION"
+```
+If it prints `n/a (no workflow invocation found)` and exits non-zero, do NOT present those as real numbers — note that totals were unavailable and which session file was checked.
 
 The full `=== Workflow Summary ===` block is written to the session log file automatically by the `workflow-summary.sh` Stop hook once the active-workflow file is removed — that's for audit only, not chat. Do not emit the full block to the user.
 

--- a/skills/smith-debug/SKILL.md
+++ b/skills/smith-debug/SKILL.md
@@ -92,11 +92,15 @@ Before any file is written (debug reports, vault logs, etc.), create an active-w
 ```bash
 SLUG=$(echo "${1:-debug}" | sed 's/[^a-zA-Z0-9._-]/-/g' | cut -c1-40)
 BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)
+# Capture the workflow's session log NOW, at the start, so end-of-workflow
+# totals read the correct file even if the session log rolls over later.
+SESSION=$(cat .smith/vault/.current-session 2>/dev/null || echo "")
 mkdir -p .smith/vault/active-workflows
 cat > .smith/vault/active-workflows/debug-${SLUG}.yaml << EOF
 workflow: smith-debug
 feature: ${SLUG}
 branch: ${BRANCH}
+session_log: $SESSION
 started: $(date -u +"%Y-%m-%dT%H:%M:%S")
 EOF
 ```
@@ -360,7 +364,13 @@ Would you like me to:
 ### If user selects [3] (Close):
 - Update the debug report status to `closed` or `documented`
 - Log the diagnosis summary (root cause and confidence level) as a regular event entry in the session log
-- Run `bash hooks/workflow-summary.sh --totals-only` and include the two lines it prints (`Total tokens used: ~<n>` and `Total duration: <d>`) verbatim at the bottom of the closing chat message
+- Run the totals command and include the lines it prints verbatim at the bottom of the closing chat message. Pass the workflow's own session log via `--session` so totals survive a mid-workflow session-log rollover:
+  ```bash
+  # $SESSION was captured at workflow start. Fall back to .current-session.
+  SESSION="${SESSION:-$(cat .smith/vault/.current-session 2>/dev/null)}"
+  bash hooks/workflow-summary.sh --totals-only --session "$SESSION"
+  ```
+  If it prints `n/a (no workflow invocation found)` and exits non-zero, do NOT present those as real numbers — note totals were unavailable and which session file was checked.
 - The full `=== Workflow Summary ===` block is appended to the session log file automatically by the `workflow-summary.sh` Stop hook once the active-workflow file is cleaned up — that's for audit only, do not duplicate it in chat
 - Log completion to vault
 

--- a/skills/smith-new/SKILL.md
+++ b/skills/smith-new/SKILL.md
@@ -98,12 +98,16 @@ The worktree is created after exploration passes (or is skipped). This ensures t
    ```bash
    # After determining branch name in step 4:
    SAFE_BRANCH=$(echo "$BRANCH" | sed 's/[^a-zA-Z0-9._-]/-/g')
+   # Capture the workflow's session log NOW, at the start, so end-of-workflow
+   # totals read the correct file even if the session log rolls over later.
+   SESSION=$(cat .smith/vault/.current-session 2>/dev/null || echo "")
    mkdir -p .smith/vault/active-workflows
    cat > .smith/vault/active-workflows/${SAFE_BRANCH}.yaml << EOF
    workflow: smith-new
    feature: <feature-name>
    branch: $BRANCH
    worktree: $WORKTREE_PATH
+   session_log: $SESSION
    started: $(date -u +"%Y-%m-%dT%H:%M:%S")
    EOF
    ```
@@ -452,7 +456,14 @@ After answers are confirmed. All work continues in `WORKTREE_PATH`. The user's m
    Phase 3.5 for the full identification heuristic and prompt
    assembly. Skip silently if no source code was edited at this stage.
 
-5. **Display final summary** to the user. Emit a chat message that starts with "Feature `<name>` complete. Here's the summary:" and includes the feature name and branch, files created/modified, PR link, release notes summary, and link to `specs/<feature>/release.md`. At the bottom, run `bash hooks/workflow-summary.sh --totals-only` and paste the two lines it prints (`Total tokens used: ~<n>` and `Total duration: <d>`) verbatim — do this BEFORE step 9 (clearing the active-workflow file) so the numbers are fresh. The bash invocation is a required action, not an optional extra — the two totals lines must appear in the chat message.
+5. **Display final summary** to the user. Emit a chat message that starts with "Feature `<name>` complete. Here's the summary:" and includes the feature name and branch, files created/modified, PR link, release notes summary, and link to `specs/<feature>/release.md`. At the bottom, run the totals command and paste the lines it prints verbatim — do this BEFORE step 9 (clearing the active-workflow file) so the numbers are fresh. Pass the workflow's own session log via `--session` so totals are computed against the correct file even if the session log rolled over mid-workflow:
+   ```bash
+   # $SESSION was captured at workflow start (step 0). Fall back to the marker's
+   # session_log field, then to .current-session, if it's not in scope here.
+   SESSION="${SESSION:-$(cat .smith/vault/.current-session 2>/dev/null)}"
+   bash hooks/workflow-summary.sh --totals-only --session "$SESSION"
+   ```
+   The bash invocation is a required action, not an optional extra — the totals lines must appear in the chat message. If it prints `n/a (no workflow invocation found)` and exits non-zero, do NOT present those as real numbers — note that totals were unavailable and which session file was checked.
 
 6. **Merge PR** from the **main repo directory** (not the worktree — avoids "main already checked out" errors):
    **IMPORTANT**: Always run `gh pr merge` from the **primary repo directory**.

--- a/tests/workflow-summary-session.test.sh
+++ b/tests/workflow-summary-session.test.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# workflow-summary-session.test.sh
+#
+# Regression tests for the session-rollover resilience of
+# hooks/workflow-summary.sh --totals-only (see
+# specs/debug/debug-2026-06-03-workflow-summary-zeros.md).
+#
+# Exercises the REAL hooks/workflow-summary.sh + hooks/workflow_summary_lib.py
+# against synthetic vaults in temp dirs. Covers:
+#   1. Session file WITH a valid /smith-new invocation marker + a minimal
+#      subagent metric block → totals are NOT the n/a degenerate form.
+#   2. Session file WITHOUT any marker → prints the n/a diagnostic to stderr
+#      and exits non-zero (FIX 2 / S1).
+#   3. --session <explicit path> overrides .current-session (FIX 1a): point
+#      .current-session at a markerless file but pass --session at a marker
+#      file; assert it reads the marker file.
+#
+# Prints PASS/FAIL per case + a summary; exits non-zero if any case fails.
+
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd -P)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd -P)
+HOOK="$REPO_ROOT/hooks/workflow-summary.sh"
+
+if [ ! -f "$HOOK" ]; then
+    echo "FATAL: hook not found: $HOOK" >&2
+    exit 2
+fi
+
+PASS=0
+FAIL=0
+
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+# write_marker_session <path> — a well-formed session log: /smith-new
+# invocation marker + one minimal v2 subagent metric block.
+write_marker_session() {
+    local path="$1"
+    cat > "$path" <<'EOF'
+# Session Log
+
+### [13:51:02] /smith-new invocation
+
+**User Request:**
+> build the thing
+
+**Synthesized Input:** build the thing
+
+## Metrics
+
+- `[13:51:05]` **Bash** ran something
+- `[13:51:30]` **Edit** edited something
+
+### [13:55:00] Subagent completed
+
+**Metrics:**
+- model: claude-opus-4
+- input_tokens: 1000
+- output_tokens: 500
+- cache_creation_input_tokens: 200
+- cache_read_input_tokens: 4000
+- tool_uses: 7
+- duration_ms: 42000
+- total_tokens: 5700
+EOF
+}
+
+# write_markerless_session <path> — a fresh, rolled-over session log with NO
+# /smith- invocation marker (this is exactly the bug condition).
+write_markerless_session() {
+    local path="$1"
+    cat > "$path" <<'EOF'
+# Session Log
+
+session_start: "2026-06-03T19:20:11"
+
+### [19:20:15] Context compacted
+
+**Reason:** rollover
+EOF
+}
+
+# make_vault — create a temp project with .smith/vault and print its root.
+make_vault() {
+    local root
+    root=$(mktemp -d)
+    mkdir -p "$root/.smith/vault/sessions"
+    printf '%s' "$root"
+}
+
+# run_totals <project_root> <extra-args...> — run the hook in --totals-only
+# mode. Captures stdout to $OUT_STDOUT, stderr to $OUT_STDERR, rc to $OUT_RC.
+run_totals() {
+    local root="$1"; shift
+    local err_file out_file
+    err_file=$(mktemp)
+    out_file=$(mktemp)
+    # Pin CLAUDE_HOOKS_DIR to THIS repo's hooks so we exercise the worktree
+    # copy of workflow_summary_lib.py, not an older installed copy in
+    # ~/.claude/hooks (the wrapper prefers $CLAUDE_HOOKS_DIR first).
+    CLAUDE_PROJECT_DIR="$root" CLAUDE_HOOKS_DIR="$REPO_ROOT/hooks" \
+        bash "$HOOK" --totals-only "$@" \
+        >"$out_file" 2>"$err_file"
+    OUT_RC=$?
+    OUT_STDOUT=$(cat "$out_file")
+    OUT_STDERR=$(cat "$err_file")
+    rm -f "$err_file" "$out_file"
+}
+
+# --- Case 1: valid marker + subagent block → non-degenerate totals ---
+ROOT=$(make_vault)
+SESS="$ROOT/.smith/vault/sessions/2026-05-28_183520.md"
+write_marker_session "$SESS"
+printf '%s' "$SESS" > "$ROOT/.smith/vault/.current-session"
+run_totals "$ROOT"
+if [ "$OUT_RC" -eq 0 ] \
+   && printf '%s' "$OUT_STDOUT" | grep -q "Token Usage:" \
+   && ! printf '%s' "$OUT_STDOUT" | grep -q "n/a"; then
+    # The subagent block alone yields non-zero normalized tokens.
+    if printf '%s' "$OUT_STDOUT" | grep -qE "Token Usage: [0-9]"; then
+        pass "case1: valid marker → non-degenerate, non-n/a totals (rc=0)"
+    else
+        fail "case1: marker present but token line not numeric: $OUT_STDOUT"
+    fi
+else
+    fail "case1: expected rc=0 + numeric Token Usage + no n/a; rc=$OUT_RC stdout=[$OUT_STDOUT] stderr=[$OUT_STDERR]"
+fi
+rm -rf "$ROOT"
+
+# --- Case 2: no marker → loud n/a diagnostic on stderr + non-zero exit ---
+ROOT=$(make_vault)
+SESS="$ROOT/.smith/vault/sessions/2026-06-03_192011.md"
+write_markerless_session "$SESS"
+printf '%s' "$SESS" > "$ROOT/.smith/vault/.current-session"
+run_totals "$ROOT"
+if [ "$OUT_RC" -ne 0 ] \
+   && printf '%s' "$OUT_STDERR" | grep -q "no /smith-(new|bugfix|debug) invocation marker found" \
+   && printf '%s' "$OUT_STDERR" | grep -qF "$SESS" \
+   && printf '%s' "$OUT_STDOUT" | grep -q "n/a (no workflow invocation found)"; then
+    pass "case2: no marker → stderr diagnostic (names file) + n/a stdout + rc!=0"
+else
+    fail "case2: expected non-zero rc + stderr diagnostic naming $SESS + n/a stdout; rc=$OUT_RC stdout=[$OUT_STDOUT] stderr=[$OUT_STDERR]"
+fi
+rm -rf "$ROOT"
+
+# --- Case 3: --session overrides .current-session (FIX 1a) ---
+ROOT=$(make_vault)
+GOOD="$ROOT/.smith/vault/sessions/2026-05-28_183520.md"   # has the marker
+BAD="$ROOT/.smith/vault/sessions/2026-06-03_192011.md"    # markerless, fresh
+write_marker_session "$GOOD"
+write_markerless_session "$BAD"
+# .current-session deliberately points at the markerless (wrong) file.
+printf '%s' "$BAD" > "$ROOT/.smith/vault/.current-session"
+# But we pass --session at the GOOD file: it must win.
+run_totals "$ROOT" --session "$GOOD"
+if [ "$OUT_RC" -eq 0 ] \
+   && printf '%s' "$OUT_STDOUT" | grep -qE "Token Usage: [0-9]" \
+   && ! printf '%s' "$OUT_STDOUT" | grep -q "n/a"; then
+    pass "case3: --session overrides .current-session → reads marker file"
+else
+    fail "case3: expected --session to win (numeric totals, rc=0); rc=$OUT_RC stdout=[$OUT_STDOUT] stderr=[$OUT_STDERR]"
+fi
+# Sanity sub-check: without --session, the same vault is degenerate (proves the
+# override is what changed the outcome, not luck).
+run_totals "$ROOT"
+if [ "$OUT_RC" -ne 0 ] && printf '%s' "$OUT_STDOUT" | grep -q "n/a"; then
+    pass "case3b: without --session, the markerless .current-session is degenerate"
+else
+    fail "case3b: expected degenerate n/a without --session; rc=$OUT_RC stdout=[$OUT_STDOUT]"
+fi
+rm -rf "$ROOT"
+
+# --- Case 4: active-workflow marker session_log: wins over .current-session (FIX 1b) ---
+ROOT=$(make_vault)
+GOOD="$ROOT/.smith/vault/sessions/2026-05-28_183520.md"   # has the marker
+BAD="$ROOT/.smith/vault/sessions/2026-06-03_192011.md"    # markerless, fresh
+write_marker_session "$GOOD"
+write_markerless_session "$BAD"
+printf '%s' "$BAD" > "$ROOT/.smith/vault/.current-session"
+mkdir -p "$ROOT/.smith/vault/active-workflows"
+cat > "$ROOT/.smith/vault/active-workflows/fix-something.yaml" <<EOF
+workflow: smith-bugfix
+feature: something
+branch: fix/something
+worktree: /tmp/wt
+session_log: $GOOD
+started: 2026-05-28T18:35:20
+EOF
+# No --session: resolution should pick up session_log from the single marker.
+run_totals "$ROOT"
+if [ "$OUT_RC" -eq 0 ] \
+   && printf '%s' "$OUT_STDOUT" | grep -qE "Token Usage: [0-9]" \
+   && ! printf '%s' "$OUT_STDOUT" | grep -q "n/a"; then
+    pass "case4: active-workflow marker session_log overrides .current-session"
+else
+    fail "case4: expected marker session_log to win; rc=$OUT_RC stdout=[$OUT_STDOUT] stderr=[$OUT_STDERR]"
+fi
+rm -rf "$ROOT"
+
+echo "----"
+echo "SUMMARY: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

`workflow-summary.sh --totals-only` printed `Token Usage: 0 / $0.00 / 0s` as if real when a long/multi-day conversation rolled the session log mid-workflow. Diagnosed in `specs/debug/debug-2026-06-03-workflow-summary-zeros.md`.

## What was broken

`--totals-only` blindly read `.smith/vault/.current-session`. When the log rolled over, that pointer moved to a fresh, markerless file; `find_invocation()` returned `None`; the lib took a degenerate branch and emitted hardcoded zeros — even though the real metrics lived in the prior session file.

## What changed

- **`hooks/workflow-summary.sh`** — adds `--session <path>` flag and a `resolve_session_file()` helper with documented precedence: (a) `--session`, (b) `session_log:` from an active-workflow marker (branch-matched when several exist), (c) `.current-session` fallback (backwards-compatible). Stop-hook mode unchanged.
- **`hooks/workflow_summary_lib.py`** — the no-marker path is now LOUD: stderr diagnostic naming the file actually read, explicit `n/a` lines (same 3-line shape), and a non-zero exit. New `render_no_marker_block()`. Missing-file in totals mode is also loud. Genuine zero-usage workflows (marker present) still render real zeros and stay distinguishable.
- **`skills/smith-new`, `skills/smith-bugfix`, `skills/smith-debug`** — capture the session log at workflow start, write it as `session_log:` into the active-workflow marker, and pass `--session "$SESSION"` to the end-of-workflow `--totals-only` call. Prose notes the n/a/non-zero case.
- **`tests/workflow-summary-session.test.sh`** — new, 5 cases against the real hook + lib.
- **`CHANGELOG.md`** — `[Unreleased] / Fixed` entry.

## Test plan

- New `tests/workflow-summary-session.test.sh`: 5/5 PASS (valid marker → non-degenerate; no marker → n/a + stderr + non-zero exit; `--session` overrides `.current-session`; markerless fallback is degenerate; active-workflow `session_log:` overrides `.current-session`).
- Existing `tests/get-base-branch.test.sh`: 8/8 PASS.
- Existing Python unit suite: 49/49 PASS (`unittest`), including `test_malformed_timestamp_not_matched`.
- `python3 -m py_compile hooks/workflow_summary_lib.py` and `bash -n` on the hook + new test: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)