### PR TITLE
fix: install scripts missed v3 helpers + left broken symlinks intact

### DIFF
--- a/scripts/install-parsers.sh
+++ b/scripts/install-parsers.sh
@@ -103,6 +103,10 @@ if $UNINSTALL; then
   uninstall_file "${TARGET_DIR}/parse-js.js"
   uninstall_file "${TARGET_DIR}/path-resolver.py"
   uninstall_file "${TARGET_DIR}/meta_describe.py"
+  uninstall_file "${TARGET_DIR}/index_common.py"
+  uninstall_file "${TARGET_DIR}/describe_discover.py"
+  uninstall_file "${TARGET_DIR}/describe_write.py"
+  uninstall_file "${TARGET_DIR}/describe_checkpoint.py"
   uninstall_file "${TARGET_DIR}/parser-lib.sh"
   uninstall_file "${TARGET_DIR}/vendor/acorn.min.js"
   log "uninstall complete"
@@ -115,11 +119,19 @@ log "install starting (source=${SOURCE_DIR}, target=${TARGET_DIR})"
 install_file "${SOURCE_DIR}/parse-python.py"           "${TARGET_DIR}/parse-python.py"           755
 install_file "${SOURCE_DIR}/parse-js.js"               "${TARGET_DIR}/parse-js.js"               755
 install_file "${SOURCE_DIR}/path-resolver.py"          "${TARGET_DIR}/path-resolver.py"          755
-# v2: meta_describe.py is the shared LLM-description helper consumed by
-# /smith-index --describe and the three smith workflows (smith-new,
-# smith-bugfix, smith-debug) via `python3 ~/.smith/scripts/meta_describe.py
-# update-touched ...`. Per data-model.md §4.
+# v2 (PR #21): meta_describe.py started life as the shared LLM helper.
+# v3 (PR #25) stripped it down to a structural module — datatypes,
+# .meta parse/render, threshold filter, prompt-template builders. Still
+# imported by all v3 helpers and the save hook.
 install_file "${SOURCE_DIR}/meta_describe.py"          "${TARGET_DIR}/meta_describe.py"          755
+# v3 (PR #25): four new helpers replace the v2 LLM-call orchestration.
+# The skill prose at ~/.claude/skills/smith-index/SKILL.md references
+# these via absolute paths (python3 ~/.smith/scripts/describe_*.py),
+# so they MUST be present on disk for /smith-index --describe to work.
+install_file "${SOURCE_DIR}/index_common.py"           "${TARGET_DIR}/index_common.py"           755
+install_file "${SOURCE_DIR}/describe_discover.py"      "${TARGET_DIR}/describe_discover.py"      755
+install_file "${SOURCE_DIR}/describe_write.py"         "${TARGET_DIR}/describe_write.py"         755
+install_file "${SOURCE_DIR}/describe_checkpoint.py"    "${TARGET_DIR}/describe_checkpoint.py"    755
 install_file "${SOURCE_DIR}/parser-lib.sh"             "${TARGET_DIR}/parser-lib.sh"             644
 install_file "${SOURCE_DIR}/vendor/acorn.min.js"       "${TARGET_DIR}/vendor/acorn.min.js"       644
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -152,7 +152,18 @@ SKILL_COUNT=0
 for skill_src in "$REPO_ROOT"/skills/smith "$REPO_ROOT"/skills/smith-*; do
     [ -d "$skill_src" ] || continue
     skill_name="$(basename "$skill_src")"
-    rm -rf "$CLAUDE_SKILLS_DIR/$skill_name"
+    target="$CLAUDE_SKILLS_DIR/$skill_name"
+    # Explicitly unlink symlinks first. Observed in practice: when
+    # `npx skills add ATTCKDigital/smith` was previously run, it symlinks
+    # ~/.claude/skills/<name> -> ../.agents/skills/<name> using a
+    # relative path. Once the npm tree is cleaned up that link is
+    # broken. A subsequent `rm -rf` on the broken-symlink path may
+    # leave the link in place (rm doesn't traverse the dangling
+    # target), after which `cp -R` either fails or copies INTO the
+    # dangling path. Force-remove the link first so cp creates a
+    # fresh directory.
+    [ -L "$target" ] && unlink "$target"
+    rm -rf "$target"
     cp -R "$skill_src" "$CLAUDE_SKILLS_DIR/"
     SKILL_COUNT=$((SKILL_COUNT + 1))
 done


### PR DESCRIPTION
## Summary

Two install-path bugs from PR #25's task-llm-backend:

- **`scripts/install-parsers.sh`**: hardcoded copy list didn't include the four new v3 helpers (`index_common.py`, `describe_discover.py`, `describe_write.py`, `describe_checkpoint.py`). Fresh `bash scripts/install.sh` left them missing, so `/smith-index --describe` failed immediately at the discover step.
- **`scripts/install.sh` skill-copy loop**: `rm -rf` followed by `cp -R` doesn't reliably replace a pre-existing broken symlink. Common in practice when `npx skills add ATTCKDigital/smith` had been run earlier (it creates relative-path symlinks that break once the npm tree is cleaned). Added `[ -L "$target" ] && unlink "$target"` ahead of the rm.

## What was broken
- Anyone running `bash scripts/install.sh` from scratch today got a partial install — the skill prose's references to `python3 ~/.smith/scripts/describe_discover.py` (etc.) all 404'd.
- Anyone with a prior `npx skills add` install ended up with a broken symlink at `~/.claude/skills/smith-update` (and potentially others) that survived a subsequent `bash scripts/install.sh`.

## What changed
- `scripts/install-parsers.sh`: added 4 `install_file` lines + 4 `uninstall_file` lines for the v3 helpers. Comment explains what each is.
- `scripts/install.sh`: explicit `unlink` of any pre-existing symlink before `rm -rf`. Comment documents the npm-install interaction.

## Test plan
- [x] `bash scripts/install-parsers.sh` against `~/.smith/scripts/`: all 4 v3 helpers installed (with `.bak.<timestamp>` backups of pre-existing copies)
- [x] Synthetic broken-symlink test: `install.sh`'s loop replaced the dangling link with a real directory containing SKILL.md
- [x] `tests/parsers/test_task_backend_stub.py`: 9/9 pass — v3 surface unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)