### PR TITLE
fix: index .liquid + .json via passive parsing

### DIFF
--- a/scripts/parsers/index_common.py
+++ b/scripts/parsers/index_common.py
@@ -37,10 +37,21 @@ from typing import Optional
 
 # --- Constants --------------------------------------------------------------
 
-ALLOWED_EXTENSIONS = {".py", ".js", ".jsx", ".ts", ".tsx", ".css", ".html", ".sh"}
+ALLOWED_EXTENSIONS = {
+    ".py",
+    ".js",
+    ".jsx",
+    ".ts",
+    ".tsx",
+    ".css",
+    ".html",
+    ".sh",
+    ".liquid",
+    ".json",
+}
 PYTHON_EXTS = {".py"}
 JS_EXTS = {".js", ".jsx", ".ts", ".tsx"}
-PASSIVE_EXTS = {".css", ".html", ".sh"}
+PASSIVE_EXTS = {".css", ".html", ".sh", ".liquid", ".json"}
 
 EXCLUDED_DIR_NAMES = {
     "node_modules",
@@ -170,7 +181,7 @@ def run_parser(
 
 
 def passive_parse(file_path: Path) -> dict:
-    """For .sh/.css/.html — just count lines, no AST."""
+    """For .sh/.css/.html/.liquid/.json — just count lines, no AST."""
     try:
         with open(file_path, "r", encoding="utf-8", errors="replace") as f:
             text = f.read()
@@ -178,7 +189,13 @@ def passive_parse(file_path: Path) -> dict:
     except OSError:
         lines = 0
     ext = file_path.suffix
-    lang = {"sh": "shell", "css": "css", "html": "html"}.get(ext.lstrip("."), "other")
+    lang = {
+        "sh": "shell",
+        "css": "css",
+        "html": "html",
+        "liquid": "liquid",
+        "json": "json",
+    }.get(ext.lstrip("."), "other")
     return {
         "path": str(file_path),
         "language": lang,

--- a/scripts/smith-index/run.py
+++ b/scripts/smith-index/run.py
@@ -40,11 +40,22 @@ from pathlib import Path
 
 # --- Constants --------------------------------------------------------------
 
-ALLOWED_EXTENSIONS = {".py", ".js", ".jsx", ".ts", ".tsx", ".css", ".html", ".sh"}
+ALLOWED_EXTENSIONS = {
+    ".py",
+    ".js",
+    ".jsx",
+    ".ts",
+    ".tsx",
+    ".css",
+    ".html",
+    ".sh",
+    ".liquid",
+    ".json",
+}
 PYTHON_EXTS = {".py"}
 JS_EXTS = {".js", ".jsx", ".ts", ".tsx"}
 # Extensions we touch but have no parser for (just count lines + hash).
-PASSIVE_EXTS = {".css", ".html", ".sh"}
+PASSIVE_EXTS = {".css", ".html", ".sh", ".liquid", ".json"}
 
 EXCLUDED_DIR_NAMES = {
     "node_modules",
@@ -315,7 +326,7 @@ def run_parser(
 
 
 def passive_parse(file_path: Path) -> dict:
-    """For .sh/.css/.html — just count lines, no AST."""
+    """For .sh/.css/.html/.liquid/.json — just count lines, no AST."""
     try:
         with open(file_path, "r", encoding="utf-8", errors="replace") as f:
             text = f.read()
@@ -323,7 +334,13 @@ def passive_parse(file_path: Path) -> dict:
     except OSError:
         lines = 0
     ext = file_path.suffix
-    lang = {"sh": "shell", "css": "css", "html": "html"}.get(ext.lstrip("."), "other")
+    lang = {
+        "sh": "shell",
+        "css": "css",
+        "html": "html",
+        "liquid": "liquid",
+        "json": "json",
+    }.get(ext.lstrip("."), "other")
     return {
         "path": str(file_path),
         "language": lang,

--- a/tests/parsers/test_passive_parse.py
+++ b/tests/parsers/test_passive_parse.py
@@ -1,0 +1,129 @@
+"""Smoke tests for index_common.passive_parse with Liquid + JSON.
+
+Verifies that .liquid and .json files (added in fix/liquid-json-passive):
+  - are recognized via ALLOWED_EXTENSIONS / PASSIVE_EXTS
+  - resolve to language="liquid" / "json" in passive_parse output
+  - get their line counts reported
+  - return empty functions/classes/imports (passive parse — no AST)
+
+Run:
+    python3 tests/parsers/test_passive_parse.py
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parent.parent
+sys.path.insert(0, str(REPO / "scripts" / "parsers"))
+
+import index_common  # noqa: E402
+
+
+LIQUID_SAMPLE = """{% comment %}
+Cart line item rendering.
+{% endcomment %}
+<div class="cart-item">
+  <span>{{ item.title }}</span>
+  <input type="number" value="{{ item.quantity }}" />
+</div>
+"""
+
+JSON_SAMPLE = """{
+  "name": "gold-canna-theme",
+  "version": "1.2.3",
+  "settings": {
+    "currency": "USD"
+  }
+}
+"""
+
+
+class ExtensionListTests(unittest.TestCase):
+    def test_liquid_in_allowed_extensions(self) -> None:
+        self.assertIn(".liquid", index_common.ALLOWED_EXTENSIONS)
+        self.assertIn(".liquid", index_common.PASSIVE_EXTS)
+
+    def test_json_in_allowed_extensions(self) -> None:
+        self.assertIn(".json", index_common.ALLOWED_EXTENSIONS)
+        self.assertIn(".json", index_common.PASSIVE_EXTS)
+
+    def test_existing_passive_exts_preserved(self) -> None:
+        for ext in (".css", ".html", ".sh"):
+            self.assertIn(ext, index_common.PASSIVE_EXTS)
+            self.assertIn(ext, index_common.ALLOWED_EXTENSIONS)
+
+
+class PassiveParseTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp(prefix="smith-passive-"))
+        self.addCleanup(self._cleanup)
+
+    def _cleanup(self) -> None:
+        import shutil
+
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _write(self, name: str, content: str) -> Path:
+        p = self.tmp / name
+        p.write_text(content, encoding="utf-8")
+        return p
+
+    def test_passive_parse_liquid_file(self) -> None:
+        path = self._write("cart-item.liquid", LIQUID_SAMPLE)
+        result = index_common.passive_parse(path)
+        self.assertEqual(result["language"], "liquid")
+        self.assertEqual(result["lines"], LIQUID_SAMPLE.count("\n"))
+        self.assertEqual(result["functions"], [])
+        self.assertEqual(result["classes"], [])
+        self.assertEqual(result["imports"], [])
+        self.assertEqual(result["errors"], [])
+
+    def test_passive_parse_json_file(self) -> None:
+        path = self._write("settings.json", JSON_SAMPLE)
+        result = index_common.passive_parse(path)
+        self.assertEqual(result["language"], "json")
+        self.assertEqual(result["lines"], JSON_SAMPLE.count("\n"))
+        self.assertEqual(result["functions"], [])
+        self.assertEqual(result["classes"], [])
+
+    def test_passive_parse_sh_regression(self) -> None:
+        path = self._write("script.sh", "#!/bin/bash\necho hello\n")
+        result = index_common.passive_parse(path)
+        self.assertEqual(result["language"], "shell")
+        self.assertEqual(result["lines"], 2)
+
+    def test_passive_parse_unknown_ext_falls_through_to_other(self) -> None:
+        path = self._write("file.unknown", "content\n")
+        result = index_common.passive_parse(path)
+        self.assertEqual(result["language"], "other")
+
+
+class WalkSourceFilesTests(unittest.TestCase):
+    """End-to-end: walk a tempdir with mixed extensions, confirm liquid +
+    json files land in the result."""
+
+    def test_walk_includes_liquid_and_json(self) -> None:
+        tmp = Path(tempfile.mkdtemp(prefix="smith-walk-"))
+        self.addCleanup(lambda: __import__("shutil").rmtree(tmp, ignore_errors=True))
+        (tmp / "snippets").mkdir()
+        (tmp / "snippets" / "cart-item.liquid").write_text(LIQUID_SAMPLE)
+        (tmp / "config").mkdir()
+        (tmp / "config" / "settings.json").write_text(JSON_SAMPLE)
+        (tmp / "script.sh").write_text("#!/bin/sh\necho hi\n")
+        (tmp / "ignored.txt").write_text("not a source ext\n")
+
+        files = index_common.walk_source_files(tmp)
+        names = {f.name for f in files}
+        self.assertIn("cart-item.liquid", names)
+        self.assertIn("settings.json", names)
+        self.assertIn("script.sh", names)
+        self.assertNotIn("ignored.txt", names)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add `.liquid` and `.json` to `ALLOWED_EXTENSIONS` + `PASSIVE_EXTS` so they're walked and produce `.meta` sidecars.
- `passive_parse()` gets two new language mappings: `liquid` and `json`.
- No AST parsing — file-level discovery + line counts + bucket assignment via the existing path resolver. The `--describe` flow still produces module-level descriptions for these files since the Task receives raw source and the prompt asks for module summarization regardless of qualifying-method count.

## What was broken

Ran `/smith-index` on a Shopify theme and only 20 of ~278 source files got indexed. 188 `.liquid` files (snippets, sections, templates) and 70 `.json` files (config, locales, theme settings) were silently dropped — leaving the manifest blind to the actual surfaces Smith workflows touch on a Shopify project.

## What changed

- `scripts/parsers/index_common.py`: extension sets + 2 new keys in the `passive_parse` language map.
- `scripts/smith-index/run.py`: mirror the same change. The constants + `passive_parse` still exist here from before the v3 helper extraction; consolidating to a single source of truth is a separate refactor (out of scope for this fix).
- `tests/parsers/test_passive_parse.py` (NEW): 8 tests covering ext membership, language resolution, an end-to-end `walk_source_files` check, and a `.sh -> "shell"` regression.

## Test plan

- [x] 8/8 new `test_passive_parse.py` pass
- [x] 9/9 PR #25 `test_task_backend_stub.py` still green (no regression)
- [x] 9/9 PR #21 `test_meta_describe.py` still green (no regression)
- [ ] **Post-merge**: re-deploy via `bash scripts/install.sh -y`, then re-run `/smith-index` on a Shopify theme — expect ~278+ entries instead of 20

## Out of scope

- Real Liquid AST parser via `@shopify/liquid` — passive covers the immediate file-discovery need. Bank for later if per-section/per-snippet detail becomes valuable.
- JSON lockfile bloat handling — `node_modules/` already excluded; root `package-lock.json` / `yarn.lock` can be gitignored or excluded via a follow-up filter if it becomes a real problem.
- Consolidating `ALLOWED_EXTENSIONS` / `PASSIVE_EXTS` between `run.py` and `index_common.py` — that's a real refactor, separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)