### PR TITLE
fix: ship meta_schema_version.txt via install-parsers.sh

### DIFF
--- a/scripts/install-parsers.sh
+++ b/scripts/install-parsers.sh
@@ -107,6 +107,7 @@ if $UNINSTALL; then
   uninstall_file "${TARGET_DIR}/describe_discover.py"
   uninstall_file "${TARGET_DIR}/describe_write.py"
   uninstall_file "${TARGET_DIR}/describe_checkpoint.py"
+  uninstall_file "${TARGET_DIR}/meta_schema_version.txt"
   uninstall_file "${TARGET_DIR}/parser-lib.sh"
   uninstall_file "${TARGET_DIR}/vendor/acorn.min.js"
   log "uninstall complete"
@@ -132,6 +133,10 @@ install_file "${SOURCE_DIR}/index_common.py"           "${TARGET_DIR}/index_comm
 install_file "${SOURCE_DIR}/describe_discover.py"      "${TARGET_DIR}/describe_discover.py"      755
 install_file "${SOURCE_DIR}/describe_write.py"         "${TARGET_DIR}/describe_write.py"         755
 install_file "${SOURCE_DIR}/describe_checkpoint.py"    "${TARGET_DIR}/describe_checkpoint.py"    755
+# Schema version marker — single source of truth for /smith-update's schema
+# drift detection. Read by /smith-index when writing .smith/index/.schema-version.
+# Mode 644 (data file, not executable).
+install_file "${SOURCE_DIR}/meta_schema_version.txt"   "${TARGET_DIR}/meta_schema_version.txt"   644
 install_file "${SOURCE_DIR}/parser-lib.sh"             "${TARGET_DIR}/parser-lib.sh"             644
 install_file "${SOURCE_DIR}/vendor/acorn.min.js"       "${TARGET_DIR}/vendor/acorn.min.js"       644
 


### PR DESCRIPTION
## Summary

`scripts/parsers/meta_schema_version.txt` (containing `2`) has been in the repo since v2 but `install-parsers.sh`'s hardcoded `install_file` list never copied it to `~/.smith/scripts/`. Two-line fix to add it.

## What was broken

After any `/smith-index` run, `.smith/index/.schema-version` came out empty/absent because the indexer reads its version from the missing source. `/smith-update` lost its schema-drift detection on future upgrades — silently.

## What changed

- `scripts/install-parsers.sh`: one `install_file` line (mode 644, data file), one matching `uninstall_file` line. Inline comment documents what the marker is for.

## Test plan

- [x] `bash scripts/install-parsers.sh` from the worktree → `~/.smith/scripts/meta_schema_version.txt` exists, `cat` returns `2`
- [ ] **Post-merge**: re-run `/smith-index` in any project; the resulting `.smith/index/.schema-version` should now be populated with the version number rather than empty

## Pattern note

This is the third install-list drift bug found in this session (after PR #27 missing the four v3 helpers and PR #28's `.liquid` / `.json` extensions). A meta-fix worth considering as a follow-up: replace the hardcoded `install_file` lines with a directory scan of `scripts/parsers/*.{py,sh,txt}` so new files automatically ship. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)