### PR TITLE
fix: expand create-active-workflow.sh allowlist for maintenance commands

### DIFF
--- a/scripts/create-active-workflow.sh
+++ b/scripts/create-active-workflow.sh
@@ -49,7 +49,12 @@ Creates an active-workflow marker at
 
 Required:
   --branch    Git branch name (e.g. fix/foo or 23-feature). Validated.
-  --workflow  One of: smith-new, smith-bugfix, smith-debug, smith-build.
+  --workflow  One of: smith-new, smith-bugfix, smith-debug, smith-build,
+              smith-index, smith-update, smith-queue, maintenance. The first
+              four are workflow skills; the last four are maintenance commands
+              that legitimately need to register a marker for the duration of
+              their run. Use `maintenance` as a generic catch-all when none
+              of the named types fit.
   --slug      Short feature slug (used in feature: field).
   --worktree  Absolute path to the worktree.
 
@@ -100,11 +105,16 @@ if ! printf '%s' "$BRANCH" | grep -qE '^[A-Za-z0-9._/-]+$'; then
     exit 2
 fi
 
-# Workflow allowlist.
+# Workflow allowlist. The first four are workflow skills; the last
+# four are maintenance commands that need a marker too (e.g.
+# /smith-index --describe writing to .meta files via Bash redirection
+# or Write-tool calls outside the SAFE_INDEX_DIRS exemption). Use
+# `maintenance` as a generic catch-all when none of the named types
+# fit cleanly.
 case "$WORKFLOW" in
-    smith-new|smith-bugfix|smith-debug|smith-build) ;;
+    smith-new|smith-bugfix|smith-debug|smith-build|smith-index|smith-update|smith-queue|maintenance) ;;
     *)
-        err "invalid --workflow: must be one of smith-new, smith-bugfix, smith-debug, smith-build (got: $WORKFLOW)"
+        err "invalid --workflow: must be one of smith-new, smith-bugfix, smith-debug, smith-build, smith-index, smith-update, smith-queue, maintenance (got: $WORKFLOW)"
         exit 2
         ;;
 esac

--- a/tests/hooks/test_create_active_workflow.sh
+++ b/tests/hooks/test_create_active_workflow.sh
@@ -83,6 +83,51 @@ setup_repo() {
     rm -rf "$repo"
 }
 
+# ---------- 3a: smith-index workflow type accepted (PR for allowlist expansion) ----------
+{
+    repo=$(setup_repo)
+    out=$(cd "$repo" && bash "$HELPER" --branch describe-armory --workflow smith-index --slug describe-armory --worktree /tmp/wt-i 2>&1)
+    rc=$?
+    assert_eq "smith-index workflow accepted exit code" 0 "$rc"
+    rm -rf "$repo"
+}
+
+# ---------- 3b: smith-update workflow type accepted ----------
+{
+    repo=$(setup_repo)
+    out=$(cd "$repo" && bash "$HELPER" --branch sync --workflow smith-update --slug sync --worktree /tmp/wt-u 2>&1)
+    rc=$?
+    assert_eq "smith-update workflow accepted exit code" 0 "$rc"
+    rm -rf "$repo"
+}
+
+# ---------- 3c: smith-queue workflow type accepted ----------
+{
+    repo=$(setup_repo)
+    out=$(cd "$repo" && bash "$HELPER" --branch process-queue --workflow smith-queue --slug process-queue --worktree /tmp/wt-q 2>&1)
+    rc=$?
+    assert_eq "smith-queue workflow accepted exit code" 0 "$rc"
+    rm -rf "$repo"
+}
+
+# ---------- 3d: generic maintenance workflow type accepted ----------
+{
+    repo=$(setup_repo)
+    out=$(cd "$repo" && bash "$HELPER" --branch maint --workflow maintenance --slug maint --worktree /tmp/wt-m 2>&1)
+    rc=$?
+    assert_eq "maintenance workflow accepted exit code" 0 "$rc"
+    rm -rf "$repo"
+}
+
+# ---------- 3e: still-unknown workflow type still rejected ----------
+{
+    repo=$(setup_repo)
+    out=$(cd "$repo" && bash "$HELPER" --branch foo --workflow random-thing --slug f --worktree /tmp/x 2>&1)
+    rc=$?
+    assert_eq "unknown workflow still rejected exit code" 2 "$rc"
+    rm -rf "$repo"
+}
+
 # ---------- 4: invalid branch (shell metachar) ----------
 {
     repo=$(setup_repo)


### PR DESCRIPTION
## Summary

PR #31 shipped `create-active-workflow.sh` with a workflow allowlist of just `smith-new / smith-bugfix / smith-debug / smith-build`. Tonight a `/smith-index --describe --yes` run on armory needed to register a marker (per the discussion in PR #32's session) but `--workflow smith-index` was rejected with exit 2. Adding the maintenance command types fixes that.

## What was broken

The four named workflow skills are not the only things that legitimately need to register a marker. `/smith-index`, `/smith-update`, `/smith-queue` (and ad-hoc maintenance tasks) all want one too — they're not "workflows" in the spec/plan/PR sense but they DO write to the filesystem and need the gate to allow that. The current workaround is passing `--workflow smith-bugfix`, a semantic stretch.

## What changed

- **`scripts/create-active-workflow.sh`** — case statement on `--workflow` now accepts `smith-new | smith-bugfix | smith-debug | smith-build | smith-index | smith-update | smith-queue | maintenance`. Usage text updated. ~6 LOC.
- **`tests/hooks/test_create_active_workflow.sh`** — 5 new test cases: each new type accepted, an unknown type still rejected (negative test). 25/25 pass (was 20/20).

## Test plan

- [x] 25/25 helper unit tests pass (5 new + 20 existing)
- [x] 12/12 gate exemption tests still green (no regression in gate behavior)
- [x] Parser suite unaffected

## Out of scope

- Making the allowlist runtime-configurable. The set of legitimate types is small and bounded; hardcoded list is fine.
- Documenting which maintenance commands SHOULD use which type. The skills (when migrated to use the helper) will hardcode the right one inline; users running the helper manually can use `maintenance` as a safe default.
- Migrating `/smith-index`, `/smith-update`, `/smith-queue` SKILL.md files to use the helper. Separate follow-up — once they self-bootstrap, the gate friction tonight disappears entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)