### PR TITLE
fix: implement .schema-version marker write + SKILL.md path-clarity

### DIFF
--- a/scripts/smith-index/run.py
+++ b/scripts/smith-index/run.py
@@ -935,6 +935,57 @@ class IndexRun:
         target.write_text(text, encoding="utf-8")
         self.logger.log("manifest.md", "top-update", "ok")
 
+    def write_schema_version_marker(self) -> None:
+        """Step 8 of skills/smith-index/SKILL.md: write the manifest's
+        schema-version marker so /smith-update can detect projects whose
+        manifest was generated against an older .meta schema.
+
+        Source of truth: meta_schema_version.txt shipped by
+        scripts/install-parsers.sh (per PR #29) into ~/.smith/scripts/.
+        In the smith-repo dev tree the same file lives at
+        scripts/parsers/meta_schema_version.txt.
+
+        Silent skip if the source file isn't installed — keeps /smith-index
+        usable even on partial installs. The marker is overwritten on
+        every full rebuild; never removed by /smith-index itself.
+        """
+        # Resolve source. Prefer global install (PARSER_DIR_GLOBAL =
+        # ~/.smith/scripts/); fall back to repo-dev tree (PARSER_DIR_REPO =
+        # <repo>/scripts/parsers/).
+        candidates = [
+            PARSER_DIR_GLOBAL / "meta_schema_version.txt",
+            PARSER_DIR_REPO / "meta_schema_version.txt",
+        ]
+        source_value: str | None = None
+        for candidate in candidates:
+            if candidate.is_file():
+                try:
+                    source_value = candidate.read_text(encoding="utf-8").strip()
+                    break
+                except OSError:
+                    continue
+        if not source_value:
+            # Partial install — log and skip. Don't fail the run.
+            self.logger.log(
+                ".schema-version",
+                "schema-version",
+                "skipped",
+                error="meta_schema_version.txt not installed",
+            )
+            return
+
+        marker = self.index_dir / ".schema-version"
+        try:
+            marker.write_text(source_value + "\n", encoding="utf-8")
+            self.logger.log(".schema-version", "schema-version", "ok")
+        except OSError as e:
+            self.logger.log(
+                ".schema-version",
+                "schema-version",
+                "failed",
+                error=str(e),
+            )
+
     def cleanup(self) -> None:
         # Remove checkpoint on clean exit.
         try:
@@ -1000,6 +1051,7 @@ def mode_full(
     run.write_system_manifests()
     duration = time.monotonic() - start
     run.write_top_manifest(duration)
+    run.write_schema_version_marker()
     run.cleanup()
 
     summary = (
@@ -1130,6 +1182,7 @@ def mode_incremental(
     run.write_system_manifests()
     duration = time.monotonic() - start
     run.write_top_manifest(duration)
+    run.write_schema_version_marker()
     run.cleanup()
     print(
         f"/smith-index --incremental: {len(targets)} files re-indexed "

--- a/skills/smith-index/SKILL.md
+++ b/skills/smith-index/SKILL.md
@@ -30,9 +30,12 @@ modify any source file in the project. All generated state is confined to
 `.smith/index/` plus optional `.bak.<timestamp>` files on template
 migration.
 
-The actual work runs in `scripts/smith-index/run.py` (called via
-`scripts/smith-index/run.sh`). The skill markdown is the entry point that
-parses `$ARGUMENTS`, decides the mode, and shells out.
+The actual work runs in `~/.smith/scripts/smith-index/run.py` (called
+via `~/.smith/scripts/smith-index/run.sh`), installed by
+`scripts/install.sh` from this repo. In the smith-repo dev tree these
+same files live at `scripts/smith-index/run.py` / `run.sh` — invoking
+either works. The skill markdown is the entry point that parses
+`$ARGUMENTS`, decides the mode, and shells out.
 
 ## Modes (flags)
 
@@ -62,11 +65,13 @@ parses `$ARGUMENTS`, decides the mode, and shells out.
    `~/.smith/logs/smith-index-<ISO8601>.jsonl` per Rule 4.
 8. **Write the schema-version marker** at `.smith/index/.schema-version`
    containing the current schema version (read from
-   `~/.claude/skills/smith/scripts/parsers/meta_schema_version.txt`,
-   falls back to the in-repo equivalent if not installed). This file lets
-   `/smith-update` detect projects whose manifest was generated against an
-   older `.meta` schema and offer to regenerate. The marker is overwritten
-   on every full rebuild — never deleted by `/smith-index` itself.
+   `~/.smith/scripts/meta_schema_version.txt`, falls back to
+   `scripts/parsers/meta_schema_version.txt` in the smith-repo dev tree
+   if the global install is missing). This file lets `/smith-update`
+   detect projects whose manifest was generated against an older `.meta`
+   schema and offer to regenerate. The marker is overwritten on every
+   full rebuild (and on `--incremental` runs that write a fresh
+   manifest); silently skipped if neither source file is found.
 9. Print a summary line:
    `/smith-index: N files indexed (N succeeded, N failed, N skipped) in T.Ts`.
 

--- a/tests/parsers/test_schema_version_marker.py
+++ b/tests/parsers/test_schema_version_marker.py
@@ -1,0 +1,161 @@
+"""Regression test for .smith/index/.schema-version marker write.
+
+skills/smith-index/SKILL.md step 8 promises this marker gets written
+on every full rebuild. PR #29 installed meta_schema_version.txt at
+~/.smith/scripts/ but run.py never wrote the .schema-version marker
+on the project side — confirmed by gold-canna-theme tonight (278
+files indexed cleanly, no .schema-version on disk).
+
+This test exercises run.py's new write_schema_version_marker method
+and confirms:
+  - The marker file gets written
+  - Content equals the meta_schema_version.txt value
+  - Missing source file → silent skip (no exception, marker absent)
+  - mode_full and mode_incremental both write it
+
+Run:
+    python3 tests/parsers/test_schema_version_marker.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parent.parent
+RUN_PY = REPO / "scripts" / "smith-index" / "run.py"
+
+
+def _load_run_py():
+    sys.path.insert(0, str(REPO / "scripts" / "parsers"))
+    spec = importlib.util.spec_from_file_location("smith_index_run", RUN_PY)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+run_mod = _load_run_py()
+
+
+class SchemaVersionMarkerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        # macOS /tmp -> /private/tmp; resolve so paths line up with
+        # IndexRun.__init__'s self.project_root.resolve().
+        self.tmp = Path(tempfile.mkdtemp(prefix="smith-schema-")).resolve()
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+
+    def _make_run(self) -> "run_mod.IndexRun":
+        log_path = self.tmp / ".smith" / "logs" / "test.jsonl"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        run = run_mod.IndexRun(project_root=self.tmp, log_path=log_path)
+        run.setup_dirs()
+        return run
+
+    def test_marker_written_from_repo_source(self) -> None:
+        """In the smith-repo dev tree, meta_schema_version.txt exists at
+        scripts/parsers/ and serves as the fallback source. The method
+        finds it and writes .schema-version."""
+        run = self._make_run()
+        run.write_schema_version_marker()
+        marker = self.tmp / ".smith" / "index" / ".schema-version"
+        self.assertTrue(
+            marker.exists(),
+            ".schema-version marker not written",
+        )
+        # Source value comes from <repo>/scripts/parsers/meta_schema_version.txt
+        source = REPO / "scripts" / "parsers" / "meta_schema_version.txt"
+        if source.exists():
+            expected = source.read_text(encoding="utf-8").strip()
+            actual = marker.read_text(encoding="utf-8").strip()
+            self.assertEqual(actual, expected)
+
+    def test_marker_silent_skip_when_source_missing(self) -> None:
+        """If neither PARSER_DIR_GLOBAL nor PARSER_DIR_REPO has
+        meta_schema_version.txt, the method silently skips — does NOT
+        raise, does NOT create an empty marker."""
+        run = self._make_run()
+        # Monkey-patch the candidate paths to point at nothing.
+        orig_global = run_mod.PARSER_DIR_GLOBAL
+        orig_repo = run_mod.PARSER_DIR_REPO
+        run_mod.PARSER_DIR_GLOBAL = self.tmp / "nonexistent-global"
+        run_mod.PARSER_DIR_REPO = self.tmp / "nonexistent-repo"
+        try:
+            run.write_schema_version_marker()
+            marker = self.tmp / ".smith" / "index" / ".schema-version"
+            self.assertFalse(
+                marker.exists(),
+                "marker should NOT exist when source is missing",
+            )
+        finally:
+            run_mod.PARSER_DIR_GLOBAL = orig_global
+            run_mod.PARSER_DIR_REPO = orig_repo
+
+    def test_marker_content_strips_whitespace(self) -> None:
+        """meta_schema_version.txt may have trailing newline; the marker
+        should contain the stripped value followed by a single newline
+        for tooling sanity (`cat` shows it cleanly)."""
+        run = self._make_run()
+        # Create a fake parser dir with our own source value
+        fake_parser_dir = self.tmp / "fake-parsers"
+        fake_parser_dir.mkdir()
+        (fake_parser_dir / "meta_schema_version.txt").write_text(
+            "  42  \n",  # Intentional whitespace
+            encoding="utf-8",
+        )
+        orig_global = run_mod.PARSER_DIR_GLOBAL
+        run_mod.PARSER_DIR_GLOBAL = fake_parser_dir
+        try:
+            run.write_schema_version_marker()
+            marker = self.tmp / ".smith" / "index" / ".schema-version"
+            self.assertEqual(marker.read_text(encoding="utf-8"), "42\n")
+        finally:
+            run_mod.PARSER_DIR_GLOBAL = orig_global
+
+    def test_global_install_takes_precedence(self) -> None:
+        """When both PARSER_DIR_GLOBAL and PARSER_DIR_REPO have the
+        source file, the global install wins."""
+        run = self._make_run()
+        fake_global = self.tmp / "fake-global"
+        fake_global.mkdir()
+        (fake_global / "meta_schema_version.txt").write_text("99\n")
+        # The real PARSER_DIR_REPO has "2" — we want to confirm "99" wins
+        orig_global = run_mod.PARSER_DIR_GLOBAL
+        run_mod.PARSER_DIR_GLOBAL = fake_global
+        try:
+            run.write_schema_version_marker()
+            marker = self.tmp / ".smith" / "index" / ".schema-version"
+            self.assertEqual(marker.read_text(encoding="utf-8").strip(), "99")
+        finally:
+            run_mod.PARSER_DIR_GLOBAL = orig_global
+
+    def test_marker_overwritten_on_rerun(self) -> None:
+        """Re-running write_schema_version_marker overwrites the prior
+        value (so /smith-update can detect schema bumps after a fresh
+        install)."""
+        run = self._make_run()
+        # First pass with value "2" from the real PARSER_DIR_REPO
+        run.write_schema_version_marker()
+        marker = self.tmp / ".smith" / "index" / ".schema-version"
+        first_content = marker.read_text(encoding="utf-8")
+        # Second pass with a fake source returning a different value
+        fake_dir = self.tmp / "bump"
+        fake_dir.mkdir()
+        (fake_dir / "meta_schema_version.txt").write_text("3\n")
+        orig_global = run_mod.PARSER_DIR_GLOBAL
+        run_mod.PARSER_DIR_GLOBAL = fake_dir
+        try:
+            run.write_schema_version_marker()
+            new_content = marker.read_text(encoding="utf-8").strip()
+            self.assertEqual(new_content, "3")
+            self.assertNotEqual(first_content.strip(), new_content)
+        finally:
+            run_mod.PARSER_DIR_GLOBAL = orig_global
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Two polish fixes diagnosed by gold-canna-theme's in-project Claude tonight:

1. **Implement step 8** — `skills/smith-index/SKILL.md` has documented since PR #21 that `/smith-index` writes `.smith/index/.schema-version` on every full rebuild. `run.py` never implemented it. Added `IndexRun.write_schema_version_marker`, wired into both `mode_full` and `mode_incremental`.
2. **SKILL.md path-clarity** — two specific path references were ambiguous or wrong. The script-location reference was repo-relative (causing every installed Claude to pause and re-locate); the `meta_schema_version.txt` source path pointed at `~/.claude/skills/smith/scripts/parsers/` which doesn't exist (PR #29 installs to `~/.smith/scripts/`).

## What was broken

In gold-canna-theme: 278 files indexed cleanly, `.schema-version` absent from disk. `/smith-update`'s schema-staleness detection effectively neutered for every project. The in-project Claude offered to escalate; this PR addresses the root cause in the global install.

Also: every fresh Claude Code session running `/smith-index` paused on invocation to check whether `scripts/smith-index/run.py` actually existed (it doesn't, in installed projects — only `~/.smith/scripts/smith-index/run.py` does). Verbose UX, ~1-2s overhead per invocation. Worse, the wrong `meta_schema_version.txt` path could send a smart Claude on a wild goose chase.

## What changed

- **`scripts/smith-index/run.py`** — `IndexRun.write_schema_version_marker` method (~50 LOC) reads from `~/.smith/scripts/meta_schema_version.txt` with fallback to `<repo>/scripts/parsers/meta_schema_version.txt`. Silent skip + JSONL log line when source missing. Hooked into `mode_full` and `mode_incremental` after `write_top_manifest`.
- **`skills/smith-index/SKILL.md`** — two path-clarity edits: leading with `~/.smith/scripts/` for script location, fixing the `meta_schema_version.txt` source path.
- **`tests/parsers/test_schema_version_marker.py`** (NEW, 5 cases) — marker written, silent skip when source missing, whitespace stripped, global install takes precedence, overwritten on re-run.

## Test plan

- [x] 5/5 new tests pass
- [x] 84/84 prior tests still green (6 preservation, 4 project_root, 9 task-backend, 9 meta_describe, 11 path_resolver, 8 passive_parse, 25 helper unit, 12 gate exemption)
- [ ] **Post-merge**: in any installed project, re-run `/smith-index` and confirm `cat .smith/index/.schema-version` returns "2"

## Out of scope

- Updating `/smith-update` to READ `.schema-version` and offer regeneration when the source version bumps. That's the consumer side; writing the marker is the prerequisite. Bank as follow-up.
- `mode_check` is read-only — no manifest writes, so no `.schema-version` write either. Intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)