### PR TITLE
fix: surface manifest Description columns from spec.md + .meta data

### DIFF
--- a/scripts/smith-index/run.py
+++ b/scripts/smith-index/run.py
@@ -576,7 +576,7 @@ def render_system_manifest(
     out.append("")
     out.append("## Description")
     if description:
-        out.append(description)
+        out.append(description.strip())
     else:
         out.append(f"Files mapped to `{system_name}` by the path resolver.")
     out.append("")
@@ -605,7 +605,10 @@ def render_system_manifest(
 
 
 def render_top_manifest(
-    systems: dict[str, list[dict]], stats: dict, last_full_index: dict | None = None
+    systems: dict[str, list[dict]],
+    stats: dict,
+    last_full_index: dict | None = None,
+    system_descriptions: dict[str, str] | None = None,
 ) -> str:
     out: list[str] = []
     out.append("# Project Manifest")
@@ -623,7 +626,7 @@ def render_top_manifest(
     # Cap to 25 rows to respect 50-line budget.
     for name in sorted_systems[:25]:
         count = len(systems[name])
-        desc = _system_description(name)
+        desc = _system_description(name, system_descriptions)
         out.append(f"| {name} | {count} | {desc} |")
     out.append("")
     out.append("## Stats")
@@ -638,7 +641,19 @@ def render_top_manifest(
     return "\n".join(out)
 
 
-def _system_description(name: str) -> str:
+def _system_description(
+    name: str, system_descriptions: dict[str, str] | None = None
+) -> str:
+    # Prefer the spec.md frontmatter `description:` field when present.
+    if system_descriptions:
+        declared = system_descriptions.get(name)
+        if declared:
+            # Collapse newlines and escape table-breaking pipes; cap at
+            # one line so the 25-row top-manifest stays readable.
+            one_line = declared.strip().replace("\n", " ").replace("|", "\\|")
+            if len(one_line) > 120:
+                one_line = one_line[:117] + "…"
+            return one_line
     if name == "unassigned":
         return "Files not assigned to any system"
     if name == "excluded":
@@ -756,6 +771,9 @@ class IndexRun:
         self.succeeded = 0
         self.failed = 0
         self.skipped = 0
+        # spec.md `description:` frontmatter per system id, loaded once.
+        # Empty dict if .specify/systems/ is missing or has no usable specs.
+        self.system_descriptions: dict[str, str] = self._load_system_descriptions()
 
     def _load_overrides(self) -> dict | None:
         if not self.system_paths_path.exists():
@@ -765,6 +783,56 @@ class IndexRun:
                 return json.load(f)
         except (OSError, json.JSONDecodeError):
             return None
+
+    def _load_system_descriptions(self) -> dict[str, str]:
+        """Map system id -> spec.md frontmatter `description:` field.
+
+        Reads `<project_root>/.specify/systems/<id>/spec.md`, falling back
+        to `<project_root>/specs/<id>/spec.md` if the canonical location
+        is missing. Returns an empty dict on any failure (missing dir,
+        unreadable file, malformed frontmatter) — the renderers degrade
+        to the legacy title-cased-slug behavior in that case.
+
+        Reuses `path_resolver._parse_yaml_frontmatter` to stay consistent
+        with Tier 1 frontmatter semantics.
+        """
+        out: dict[str, str] = {}
+        if path_resolver is None or not hasattr(
+            path_resolver, "_parse_yaml_frontmatter"
+        ):
+            return out
+        parse_fm = path_resolver._parse_yaml_frontmatter  # type: ignore[attr-defined]
+        for base in (
+            self.project_root / ".specify" / "systems",
+            self.project_root / "specs",
+        ):
+            if not base.is_dir():
+                continue
+            try:
+                entries = sorted(p for p in base.iterdir() if p.is_dir())
+            except OSError:
+                continue
+            for system_dir in entries:
+                spec_path = system_dir / "spec.md"
+                if not spec_path.is_file():
+                    continue
+                try:
+                    fm = parse_fm(str(spec_path))
+                except Exception:
+                    continue
+                if not fm:
+                    continue
+                # `system:` frontmatter overrides the directory name.
+                system_id = fm.get("system") or system_dir.name
+                if not isinstance(system_id, str) or not system_id:
+                    system_id = system_dir.name
+                desc = fm.get("description")
+                if isinstance(desc, str) and desc.strip():
+                    # First spec wins for a given id; .specify/systems/
+                    # is consulted before specs/ so canonical specs are
+                    # preferred over legacy ones.
+                    out.setdefault(system_id, desc.strip())
+        return out
 
     def setup_dirs(self) -> None:
         for d in (self.index_dir, self.files_dir, self.systems_dir, self.config_dir):
@@ -920,7 +988,8 @@ class IndexRun:
 
     def write_system_manifests(self) -> None:
         for system, entries in self.systems.items():
-            text = render_system_manifest(system, entries)
+            description = self.system_descriptions.get(system, "")
+            text = render_system_manifest(system, entries, description=description)
             target = self.systems_dir / f"{system}.md"
             target.write_text(text, encoding="utf-8")
             self.logger.log(system, "system-update", "ok")
@@ -930,7 +999,12 @@ class IndexRun:
 
     def write_top_manifest(self, duration_s: float) -> None:
         last_full = {"duration_s": duration_s, "timestamp": iso_now()}
-        text = render_top_manifest(self.systems, self.stats, last_full_index=last_full)
+        text = render_top_manifest(
+            self.systems,
+            self.stats,
+            last_full_index=last_full,
+            system_descriptions=self.system_descriptions,
+        )
         target = self.index_dir / "manifest.md"
         target.write_text(text, encoding="utf-8")
         self.logger.log("manifest.md", "top-update", "ok")
@@ -1187,6 +1261,47 @@ def mode_incremental(
     print(
         f"/smith-index --incremental: {len(targets)} files re-indexed "
         f"in {duration:.1f}s"
+    )
+    return 0
+
+
+def mode_rebuild_manifests(project_root: Path, log_path: Path) -> int:
+    """Re-render manifest.md + systems/*.md from existing .meta files.
+
+    Use case: after `/smith-index --describe` has updated `.meta` files
+    with newly-generated module descriptions, the manifest tables still
+    reflect the pre-describe state (process_file's per-system entries
+    are populated DURING the source walk, before --describe runs). This
+    mode lets the describe skill propagate those descriptions to the
+    manifests without re-parsing every source file.
+
+    Behavior:
+    - Reads .smith/index/files/*.meta only; never re-runs language parsers.
+    - Rebuilds run.systems + run.stats via _refresh_full_aggregations,
+      which salvages module_description from each .meta's description layer.
+    - Writes systems/<id>.md and manifest.md with the refreshed aggregations.
+    - Does NOT touch .meta files or .schema-version (those are owned by
+      mode_full / mode_incremental).
+    - No-op (exit 0 with a message) if .smith/index/files/ doesn't exist —
+      the project hasn't been indexed at all.
+    """
+    start = time.monotonic()
+    run = IndexRun(project_root, log_path)
+    if not run.files_dir.exists():
+        print(
+            "/smith-index --rebuild-manifests: no .smith/index/files/ found. "
+            "Run /smith-index first."
+        )
+        return 0
+    run.setup_dirs()
+    _refresh_full_aggregations(run)
+    run.write_system_manifests()
+    duration = time.monotonic() - start
+    run.write_top_manifest(duration)
+    run.cleanup()
+    print(
+        f"/smith-index --rebuild-manifests: {run.stats['total']} files "
+        f"aggregated from .meta in {duration:.1f}s"
     )
     return 0
 
@@ -1495,6 +1610,15 @@ def main(argv: list[str]) -> int:
         help="Generate stub system-paths.json from top-level dirs",
     )
     parser.add_argument(
+        "--rebuild-manifests",
+        action="store_true",
+        help=(
+            "Re-render manifest.md and systems/*.md from existing .meta "
+            "files without re-parsing source. Used by /smith-index "
+            "--describe to propagate newly-generated descriptions."
+        ),
+    )
+    parser.add_argument(
         "--resume", action="store_true", help="Resume from existing checkpoint"
     )
     parser.add_argument("--from", dest="from_ref", help="Incremental from-ref")
@@ -1521,6 +1645,8 @@ def main(argv: list[str]) -> int:
         return mode_incremental(project_root, log_path, args.from_ref, args.to_ref)
     if args.init_system_paths:
         return mode_init_system_paths(project_root)
+    if args.rebuild_manifests:
+        return mode_rebuild_manifests(project_root, log_path)
 
     # Default: full rebuild (optionally filtered).
     system_paths = Path(args.system_paths) if args.system_paths else None

--- a/skills/smith-index/SKILL.md
+++ b/skills/smith-index/SKILL.md
@@ -260,7 +260,30 @@ For each file in the batch:
      --processed "$REL"
    ```
 
-#### Step 5 — Summary
+#### Step 5 — Propagate descriptions to manifest tables
+
+`/smith-index` (full rebuild) populates per-file rows in
+`systems/<id>.md` and the top-level `manifest.md` during its source
+walk — well before `--describe` writes the description layer into each
+`.meta`. The manifest tables therefore reflect the pre-describe state.
+
+After all batches complete, refresh the manifest tables from the
+just-updated `.meta` files:
+
+```bash
+python3 ~/.smith/scripts/smith-index/run.py --rebuild-manifests \
+  --root "$ROOT"
+```
+
+(Falls back to `scripts/smith-index/run.py` in repo-dev layouts.)
+
+This mode re-reads `.smith/index/files/*.meta`, salvages the module
+descriptions from each file's description layer, and re-renders
+`manifest.md` + every `systems/<id>.md`. It does NOT re-parse source
+or touch `.meta` files. Skipped if `--describe` aborted before any
+descriptions were written.
+
+#### Step 6 — Summary
 
 After all batches complete (or on abort):
 

--- a/tests/parsers/test_run_manifest_descriptions.py
+++ b/tests/parsers/test_run_manifest_descriptions.py
@@ -1,0 +1,337 @@
+"""Regression tests for /smith-index manifest description rendering.
+
+Three related bugs fixed together (see PR for this commit):
+
+  Bug A: Top-level manifest.md "Description" column always showed a
+         title-cased slug (e.g. "Email Archive Contact Graph") and never
+         the actual spec.md frontmatter `description:` field. Fix:
+         IndexRun.system_descriptions loads spec.md frontmatter at run
+         start; render_top_manifest threads it through _system_description.
+
+  Bug B: render_system_manifest() was called without the `description=`
+         argument from write_system_manifests(), so each system's
+         `## Description` header was the generic "Files mapped to `<system>`
+         by the path resolver." fallback even when the spec declared a
+         description. Fix: write_system_manifests passes
+         self.system_descriptions[<system>].
+
+  Bug C: After /smith-index --describe wrote descriptions into .meta
+         files, the manifest tables still reflected the pre-describe
+         state because process_file's per-system entries are populated
+         during the source walk (before --describe runs). Fix: new
+         --rebuild-manifests mode reads existing .meta files and
+         re-renders manifest.md + systems/*.md without re-parsing source.
+
+Run:
+    python3 tests/parsers/test_run_manifest_descriptions.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parent.parent
+RUN_PY = REPO / "scripts" / "smith-index" / "run.py"
+
+
+def _load_run_py():
+    sys.path.insert(0, str(REPO / "scripts" / "parsers"))
+    spec = importlib.util.spec_from_file_location("smith_index_run", RUN_PY)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+run_mod = _load_run_py()
+
+
+SPEC_WITH_DESCRIPTION = """\
+---
+system: system-04-personal-voice
+status: active
+description: Personal voice training subsystem — fine-tunes per-user response style from past message archives.
+paths:
+  - services/voice-training
+---
+
+# system-04-personal-voice
+
+Body content.
+"""
+
+SPEC_WITHOUT_DESCRIPTION = """\
+---
+system: system-99-misc
+status: active
+paths:
+  - services/misc
+---
+
+# system-99-misc
+
+Body content.
+"""
+
+SAMPLE_PY = '''"""Sample module."""
+
+
+def fn(x: int) -> int:
+    """Sample fn."""
+    a = x + 1
+    a = a * 2
+    return a
+'''
+
+SEEDED_META = """\
+# services/voice-training/foo.py
+Last Updated: 2026-06-04T00:00:00Z
+Language: python
+Lines: 12
+Hash: deadbeefcafebabe
+**Description:** Sample module — provides a single utility fn used in tests.
+Described-Against-Hash: deadbeefcafebabe
+Described-At: 2026-06-04T00:00:00Z
+
+## Imports
+
+_None._
+
+## Routes
+
+_None._
+
+## Classes
+
+_None._
+
+## Functions
+
+- `fn(x: int) -> int` (line 4)
+  Id: aaaaaaaaaaaaaaaa
+  Description: SEEDED-FN-DESCRIPTION
+
+## Exports
+
+_None._
+
+## Parse Errors
+
+_None._
+"""
+
+
+class ManifestDescriptionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        # macOS /tmp -> /private/tmp; resolve so IndexRun's resolve()
+        # canonical form matches.
+        self.tmp = Path(tempfile.mkdtemp(prefix="smith-manifest-desc-")).resolve()
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+
+    def _write_spec(self, system_dir_name: str, body: str) -> None:
+        spec_dir = self.tmp / ".specify" / "systems" / system_dir_name
+        spec_dir.mkdir(parents=True, exist_ok=True)
+        (spec_dir / "spec.md").write_text(body, encoding="utf-8")
+
+    def _make_index_run(self) -> "run_mod.IndexRun":
+        log_path = self.tmp / ".smith" / "logs" / "test.jsonl"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        run = run_mod.IndexRun(project_root=self.tmp, log_path=log_path)
+        run.setup_dirs()
+        return run
+
+    # ------------------------------------------------------------------
+    # Bug A: top-level manifest reads spec description
+    # ------------------------------------------------------------------
+
+    def test_top_manifest_uses_spec_description_when_present(self) -> None:
+        self._write_spec("system-04-personal-voice", SPEC_WITH_DESCRIPTION)
+        run = self._make_index_run()
+        text = run_mod.render_top_manifest(
+            systems={"system-04-personal-voice": [{"path": "x", "lines": 1}]},
+            stats={"total": 1, "over_200": 0, "over_300": 0, "over_500": 0},
+            system_descriptions=run.system_descriptions,
+        )
+        self.assertIn("Personal voice training subsystem", text)
+        # Sanity: legacy title-case slug should NOT appear for this system.
+        # (the bug surfaced because that was the only string emitted)
+        self.assertNotIn("| system-04-personal-voice | 1 | 04 Personal Voice", text)
+
+    def test_top_manifest_falls_back_to_title_case_when_spec_missing(self) -> None:
+        # No spec written at all — system_descriptions is empty.
+        run = self._make_index_run()
+        self.assertEqual(run.system_descriptions, {})
+        text = run_mod.render_top_manifest(
+            systems={"system-foo-bar": [{"path": "x", "lines": 1}]},
+            stats={"total": 1, "over_200": 0, "over_300": 0, "over_500": 0},
+            system_descriptions=run.system_descriptions,
+        )
+        # Legacy title-case behavior preserved.
+        self.assertIn("Foo Bar", text)
+
+    def test_top_manifest_falls_back_when_spec_omits_description(self) -> None:
+        self._write_spec("system-99-misc", SPEC_WITHOUT_DESCRIPTION)
+        run = self._make_index_run()
+        # spec exists but has no description: → not in dict
+        self.assertNotIn("system-99-misc", run.system_descriptions)
+        text = run_mod.render_top_manifest(
+            systems={"system-99-misc": [{"path": "x", "lines": 1}]},
+            stats={"total": 1, "over_200": 0, "over_300": 0, "over_500": 0},
+            system_descriptions=run.system_descriptions,
+        )
+        self.assertIn("99 Misc", text)
+
+    # ------------------------------------------------------------------
+    # Bug B: per-system manifest header gets the spec description
+    # ------------------------------------------------------------------
+
+    def test_system_manifest_header_uses_spec_description(self) -> None:
+        self._write_spec("system-04-personal-voice", SPEC_WITH_DESCRIPTION)
+        run = self._make_index_run()
+        # Seed an entry so write_system_manifests has something to write.
+        run.systems["system-04-personal-voice"] = [
+            {
+                "path": "services/voice-training/foo.py",
+                "lines": 12,
+                "exports": "(see .meta)",
+                "exceeds": False,
+                "module_description": "",
+            }
+        ]
+        run.write_system_manifests()
+        target = run.systems_dir / "system-04-personal-voice.md"
+        text = target.read_text(encoding="utf-8")
+        self.assertIn(
+            "Personal voice training subsystem",
+            text,
+            "system manifest header should contain spec description",
+        )
+        # Sanity: the generic fallback should NOT appear when a real
+        # description is available.
+        self.assertNotIn(
+            "Files mapped to `system-04-personal-voice` by the path resolver.",
+            text,
+        )
+
+    def test_system_manifest_falls_back_when_no_description(self) -> None:
+        # No specs written — system has no declared description.
+        run = self._make_index_run()
+        run.systems["system-orphan"] = [
+            {
+                "path": "x",
+                "lines": 1,
+                "exports": "(none)",
+                "exceeds": False,
+                "module_description": "",
+            }
+        ]
+        run.write_system_manifests()
+        text = (run.systems_dir / "system-orphan.md").read_text(encoding="utf-8")
+        self.assertIn("Files mapped to `system-orphan` by the path resolver.", text)
+
+    # ------------------------------------------------------------------
+    # Bug C: --rebuild-manifests propagates module descriptions
+    # ------------------------------------------------------------------
+
+    def test_rebuild_manifests_pulls_module_description_from_meta(self) -> None:
+        """The whole point: after --describe writes descriptions to .meta,
+        --rebuild-manifests should pick them up and put them in the
+        per-system manifest's Description column."""
+        # Seed a spec so the system bucket is "system-04-personal-voice".
+        self._write_spec("system-04-personal-voice", SPEC_WITH_DESCRIPTION)
+        # Seed a source file under the declared path.
+        rel = "services/voice-training/foo.py"
+        src = self.tmp / rel
+        src.parent.mkdir(parents=True, exist_ok=True)
+        src.write_text(SAMPLE_PY, encoding="utf-8")
+        # Seed a .meta with descriptions (simulating post-describe state).
+        meta_path = self.tmp / ".smith" / "index" / "files" / (rel + ".meta")
+        meta_path.parent.mkdir(parents=True, exist_ok=True)
+        meta_path.write_text(SEEDED_META, encoding="utf-8")
+
+        log_path = self.tmp / ".smith" / "logs" / "rebuild.jsonl"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        rc = run_mod.mode_rebuild_manifests(self.tmp, log_path)
+        self.assertEqual(rc, 0)
+
+        # System manifest's per-file Description column now shows the
+        # description salvaged from .meta.
+        system_md = (
+            self.tmp / ".smith" / "index" / "systems" / "system-04-personal-voice.md"
+        )
+        self.assertTrue(system_md.exists())
+        text = system_md.read_text(encoding="utf-8")
+        self.assertIn(
+            "Sample module — provides a single utility fn used in tests.",
+            text,
+        )
+        # Header description is also there (Bug B coupling).
+        self.assertIn("Personal voice training subsystem", text)
+
+    def test_rebuild_manifests_no_op_when_no_index(self) -> None:
+        """Should be friendly when there's no .smith/index/files/ yet."""
+        log_path = self.tmp / ".smith" / "logs" / "rebuild.jsonl"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        rc = run_mod.mode_rebuild_manifests(self.tmp, log_path)
+        # No crash, no manifest written.
+        self.assertEqual(rc, 0)
+        self.assertFalse((self.tmp / ".smith" / "index" / "manifest.md").exists())
+
+    def test_rebuild_manifests_does_not_touch_meta_files(self) -> None:
+        """--rebuild-manifests must be read-only on .meta files."""
+        self._write_spec("system-04-personal-voice", SPEC_WITH_DESCRIPTION)
+        rel = "services/voice-training/foo.py"
+        src = self.tmp / rel
+        src.parent.mkdir(parents=True, exist_ok=True)
+        src.write_text(SAMPLE_PY, encoding="utf-8")
+        meta_path = self.tmp / ".smith" / "index" / "files" / (rel + ".meta")
+        meta_path.parent.mkdir(parents=True, exist_ok=True)
+        meta_path.write_text(SEEDED_META, encoding="utf-8")
+        before_mtime = meta_path.stat().st_mtime_ns
+        before_text = meta_path.read_text(encoding="utf-8")
+
+        log_path = self.tmp / ".smith" / "logs" / "rebuild.jsonl"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        run_mod.mode_rebuild_manifests(self.tmp, log_path)
+
+        # Content unchanged (mtime may shift if filesystem rewrites, so
+        # assert content equality is the load-bearing check).
+        self.assertEqual(meta_path.read_text(encoding="utf-8"), before_text)
+        _ = before_mtime  # not strictly asserted, see above
+
+    # ------------------------------------------------------------------
+    # _load_system_descriptions edge cases
+    # ------------------------------------------------------------------
+
+    def test_load_system_descriptions_handles_specs_dir(self) -> None:
+        """Both .specify/systems/<id>/spec.md (canonical) and specs/<id>/spec.md
+        (legacy) should be readable, with .specify/ winning when both exist."""
+        # Legacy specs/ location with one description.
+        legacy_dir = self.tmp / "specs" / "system-foo"
+        legacy_dir.mkdir(parents=True, exist_ok=True)
+        (legacy_dir / "spec.md").write_text(
+            "---\nsystem: system-foo\ndescription: legacy desc\n---\n",
+            encoding="utf-8",
+        )
+        # Canonical .specify/ location with a different description.
+        canonical_dir = self.tmp / ".specify" / "systems" / "system-foo"
+        canonical_dir.mkdir(parents=True, exist_ok=True)
+        (canonical_dir / "spec.md").write_text(
+            "---\nsystem: system-foo\ndescription: canonical desc\n---\n",
+            encoding="utf-8",
+        )
+        run = self._make_index_run()
+        self.assertEqual(run.system_descriptions.get("system-foo"), "canonical desc")
+
+    def test_load_system_descriptions_empty_when_no_specs(self) -> None:
+        run = self._make_index_run()
+        self.assertEqual(run.system_descriptions, {})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Three related bugs in `/smith-index` manifest rendering — the Description columns in both `manifest.md` and per-system manifest files don't surface data that already exists on disk.

User-visible symptom (armory tonight): ran `--describe` successfully (1246/1256 `.meta` files have real descriptions), but `manifest.md` Description column showed title-cased slugs and system manifests' per-file Description columns were blank.

## What was broken

**Bug A — Top-level manifest used slug, not spec description.**
`_system_description(name)` at run.py:641-652 just title-cased the system slug. It never read the system spec's actual description, so the top-level manifest always showed "Email Archive Contact Graph" instead of the real spec description.

**Bug B — Per-system manifest header was always the generic fallback.**
`write_system_manifests` called `render_system_manifest(system, entries)` without the `description=` argument (signature accepts it as kwarg) at run.py:923. So every per-system manifest showed `"Files mapped to `<system>` by the path resolver."` even when the spec declared a real description.

**Bug C — Per-file Description column stayed empty after `--describe`.**
`process_file`'s per-system entry is populated DURING the source walk, which runs BEFORE `--describe` writes the description layer into `.meta` files. The manifests therefore reflect pre-describe state. Armory's `system-11-lead-generation-outreach.md` had `module_description=""` for every row even though every `.meta` had a real description on disk.

## What changed

**`scripts/smith-index/run.py` (~130 LOC added)**

- `IndexRun._load_system_descriptions()` — reads `spec.md` frontmatter `description:` field from `.specify/systems/<id>/` (canonical) with fallback to `specs/<id>/` (legacy). Reuses `path_resolver._parse_yaml_frontmatter` so semantics stay consistent with Tier 1. Empty dict on any failure → renderers degrade to legacy title-case behavior.
- `render_top_manifest` now accepts `system_descriptions=` kwarg; `_system_description(name, system_descriptions=)` prefers the spec description when present, escapes pipes, caps at 120 chars.
- `write_system_manifests` passes `self.system_descriptions.get(system, "")` to `render_system_manifest`'s `description=` arg. Header now strips trailing whitespace.
- `mode_rebuild_manifests` — new mode. Reads existing `.meta` files via the pre-existing `_refresh_full_aggregations` helper (which already salvages `module_description` from each file's description layer), then re-renders `manifest.md` + `systems/*.md` without re-parsing source. No `.meta` writes, no source walk. Graceful no-op when `.smith/index/files/` doesn't exist.
- `--rebuild-manifests` CLI flag wired up in `main`.

**`skills/smith-index/SKILL.md`**

- New "Step 5 — Propagate descriptions to manifest tables" calls `python3 ~/.smith/scripts/smith-index/run.py --rebuild-manifests --root "$ROOT"` after `--describe` finishes its batch loop. Existing Step 5 (summary) renumbered to Step 6.
- Explanation makes clear why this step is necessary: process_file populates per-system entries BEFORE the Task-driven description loop runs.

**`tests/parsers/test_run_manifest_descriptions.py` (NEW, 10 cases)**

- `test_top_manifest_uses_spec_description_when_present` — Bug A primary
- `test_top_manifest_falls_back_to_title_case_when_spec_missing` — Bug A fallback
- `test_top_manifest_falls_back_when_spec_omits_description` — Bug A partial frontmatter
- `test_system_manifest_header_uses_spec_description` — Bug B primary
- `test_system_manifest_falls_back_when_no_description` — Bug B fallback
- `test_rebuild_manifests_pulls_module_description_from_meta` — Bug C primary
- `test_rebuild_manifests_no_op_when_no_index` — Bug C graceful degrade
- `test_rebuild_manifests_does_not_touch_meta_files` — Bug C read-only invariant
- `test_load_system_descriptions_handles_specs_dir` — .specify/ takes priority over specs/
- `test_load_system_descriptions_empty_when_no_specs` — empty dict graceful

## Manual verification

Ran `python3 scripts/smith-index/run.py --rebuild-manifests --root ~/Projects/armory` after this PR's changes:

```
/smith-index --rebuild-manifests: 1256 files aggregated from .meta in 0.4s
```

Confirmed every armory `.meta` description now shows up in `systems/<id>.md` per-file Description column, e.g.:
```
| services/lead-generation/lead_generation/__init__.py | 3 | Lead Generation & Outreach subsystem: lead scoring, personalized outreach templates, and conversation tracking. | (see .meta) |
```

Top-level manifest still shows title-case for armory because armory's spec.md files don't have a `description:` frontmatter field yet — that's expected (Bug A only activates when the spec declares one). Adding `description:` to armory's spec frontmatter would surface it in `manifest.md` Description column on the next `/smith-index` run.

Pattern follows PR #32 (preservation fix) and PR #34 (.schema-version write) — runner didn't fully implement documented manifest semantics.

## Test plan

- [x] `python3 tests/parsers/test_run_manifest_descriptions.py` — 10/10 pass
- [x] Full parsers suite: 87 tests pass
- [x] Shell suites: test_create_active_workflow.sh (25), test_workflow_gate_exemption.sh (12), test_parse_js.sh (24), test_stable_id_js.sh (15) — all pass
- [x] `mode_rebuild_manifests` verified end-to-end against armory's real .meta corpus

🤖 Generated with [Claude Code](https://claude.com/claude-code)