### PR TITLE
fix: ignore transient vault markers (.warned-manifest-missing-*, .active-workflow)

### DIFF
--- a/skills/smith-index/templates/.gitignore-smith-additions
+++ b/skills/smith-index/templates/.gitignore-smith-additions
@@ -14,6 +14,9 @@
 .smith/index/.smith-index-describe-checkpoint.json
 .smith/vault/.current-session
 .smith/vault/.current-session-*
+# transient per-session / per-user runtime markers (0-byte dedup + stray workflow marker)
+.smith/vault/.warned-manifest-missing-*
+.smith/vault/.active-workflow
 .smith/vault/active-workflows/
 .smith/vault/queue/
 .smith/vault/todo/


### PR DESCRIPTION
## Summary
- The Feature 36 gitignore policy missed two transient per-session/per-user vault markers. Added both to the canonical template, inside the sentinel region.

## What was broken
`skills/smith-index/templates/.gitignore-smith-additions` ignored `.current-session*`, `queue/`, `todo/`, `active-workflows/` — but NOT:
- `.smith/vault/.warned-manifest-missing-*` — 0-byte per-session dedup markers (one per session UUID) written by `context-loader-lib.py` to suppress duplicate "manifest missing" warnings.
- `.smith/vault/.active-workflow` — a stray transient workflow marker file (distinct from the already-ignored `active-workflows/` directory).

Both are the same class as `.current-session` (transient per-user/per-session runtime) and should not be committed or shared with the team. Flagged by a teammate reviewing another project's `.smith/` diff. Neither pattern is tracked in any project yet, so this only closes a future-risk gap.

## What changed
- **skills/smith-index/templates/.gitignore-smith-additions**: added two lines inside the `# >>> smith-gitignore-policy >>>` … `# <<< smith-gitignore-policy <<<` region, in the IGNORED section. No other policy line changed; `.gitattributes` template and the smith/smith-update merge logic untouched — the existing `/smith-update` §5.5 sentinel re-merge propagates these to projects automatically.

## Test plan
- [x] Sentinel integrity: exactly one open + one close marker
- [x] `git check-ignore`: both new patterns match (`.warned-manifest-missing-abc123`, `.active-workflow`); shared paths (`sessions/*.md`, `index/files/*.meta`, `ledger/`) still NOT ignored
- [x] Only the template file changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)