### PR TITLE
fix: ignore client-billing timesheets/, document .schema-version as shared

### DIFF
--- a/skills/smith-index/templates/.gitignore-smith-additions
+++ b/skills/smith-index/templates/.gitignore-smith-additions
@@ -4,7 +4,7 @@
 # sentinel markers are never touched by Smith.
 #
 # COMMITTED (shared with the team):
-#   .smith/index/manifest.md, .smith/index/config/
+#   .smith/index/manifest.md, .smith/index/config/, .smith/index/.schema-version
 #   .smith/index/files/ + .smith/index/systems/  (the --describe .meta layer)
 #   .smith/vault/ledger/, .smith/vault/bank/, .smith/vault/agents/
 #   .smith/vault/sessions/*.md
@@ -20,5 +20,7 @@
 .smith/vault/active-workflows/
 .smith/vault/queue/
 .smith/vault/todo/
+# client-billing timesheets — kept local, never shared by default
+.smith/vault/timesheets/
 .smith/config/
 # <<< smith-gitignore-policy <<<


### PR DESCRIPTION
## Summary
- Close two orphaned-path gaps in the Feature 36 negative-list gitignore policy (paths that were neither shared nor ignored).

## What was broken
A project review surfaced two `.smith/` paths the policy didn't cover:
- **`.smith/vault/timesheets/`** — client-billing `.md` files (armory has 3, goldcanna 8). Uncovered → a stray `git add -A` could commit billing data to a shared remote.
- **`.smith/index/.schema-version`** — a tiny index-schema-version marker that pairs with the shared `.meta` describe layer. Already shareable under the negative list, but undocumented (looked like an accidental orphan).

## What changed
- **skills/smith-index/templates/.gitignore-smith-additions** (managed sentinel region only):
  - Added `.smith/vault/timesheets/` to the IGNORED section (client-billing → kept local).
  - Documented `.smith/index/.schema-version` in the COMMITTED comment (explicit share; no functional line needed since the negative list already shares it).
- `.gitattributes` template and smith/smith-update merge logic untouched — `/smith-update` §5.5 re-merge propagates to projects.

## Test plan
- [x] Sentinel integrity: 1 open + 1 close marker
- [x] `git check-ignore`: `timesheets/x.md` ignored; `.schema-version`, `manifest.md`, `sessions/*.md` NOT ignored
- [x] Only the template file changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)