### PR TITLE
fix: remove Co-Authored-By trailer from Smith commit-message instructions

### DIFF
--- a/skills/smith-bugfix/SKILL.md
+++ b/skills/smith-bugfix/SKILL.md
@@ -307,9 +307,7 @@ If the fix is relevant to project status tracking, update `STATUS.md`.
 ### 7.1 Commit
 ```bash
 git add <all modified files — list explicitly, never git add -A>
-git commit -m "fix: <description>
-
-Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+git commit -m "fix: <description>"
 ```
 
 - Use `fix:` conventional commit prefix

--- a/skills/smith-build/SKILL.md
+++ b/skills/smith-build/SKILL.md
@@ -277,9 +277,7 @@ If the build cannot determine what to update in a system spec (ambiguous changes
 ### 5.1 Commit
 ```bash
 git add <all modified files — list explicitly, not git add -A>
-git commit -m "<conventional commit message>
-
-Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+git commit -m "<conventional commit message>"
 ```
 
 - Use conventional commits format
@@ -637,9 +635,7 @@ Write `specs/<feature>/release.md`:
 ### 7.2 Commit Release Notes
 ```bash
 git add specs/<feature>/release.md
-git commit -m "docs: add release notes for <feature>
-
-Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+git commit -m "docs: add release notes for <feature>"
 git push origin main
 ```
 

--- a/skills/smith-finish/SKILL.md
+++ b/skills/smith-finish/SKILL.md
@@ -104,8 +104,6 @@ Write a conventional commit message:
 ```bash
 git commit -m "$(cat <<'EOF'
 <type>: <concise description>
-
-Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
 EOF
 )"
 ```
@@ -157,9 +155,7 @@ Before creating/merging the PR, update documentation:
 6. **Commit spec updates** on the same branch:
    ```bash
    git add <spec files> CHANGELOG.md STATUS.md
-   git commit -m "docs: update specs and changelog for <feature/fix description>
-
-   Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+   git commit -m "docs: update specs and changelog for <feature/fix description>"
    git push
    ```
 

--- a/skills/smith-new/SKILL.md
+++ b/skills/smith-new/SKILL.md
@@ -370,9 +370,7 @@ After answers are confirmed. All work continues in `WORKTREE_PATH`. The user's m
    b. **Commit spec artifacts** in the worktree — stage and commit all files in the feature spec folder (spec.md, plan.md, questions.md, research.md, data-model.md, contracts/, checklists/):
       ```bash
       cd $WORKTREE_PATH && git add <feature-spec-folder>/
-      cd $WORKTREE_PATH && git commit -m "docs: spec artifacts for <feature-name> — ready for queued build
-
-      Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+      cd $WORKTREE_PATH && git commit -m "docs: spec artifacts for <feature-name> — ready for queued build"
       ```
    c. **Push the feature branch from the worktree:**
       ```bash

--- a/skills/smith-sync/SKILL.md
+++ b/skills/smith-sync/SKILL.md
@@ -128,9 +128,7 @@ Sweep team-shareable .smith/ artifacts to the default branch so teammates
 receive accumulated index + vault context. Artifact-only; no source changes.
 
 Files: ${N_TOTAL} total — ${N_SESSIONS} sessions, ${N_META} .meta,
-${N_LEDGER} ledger, ${N_BANK} bank, ${N_AGENTS} agents.
-
-Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+${N_LEDGER} ledger, ${N_BANK} bank, ${N_AGENTS} agents."
 ```
 
 ### 8. Push — direct to the default branch, NO PR


### PR DESCRIPTION
## Summary
- Removed the `Co-Authored-By: Claude ...` trailer from all Smith skill commit-message instructions. It was never requested and was being appended to every Smith-generated commit.

## What was broken
5 skills instructed the agent to append a `Co-Authored-By` trailer to commits (7 occurrences). Unwanted attribution on every Smith commit — and, when the workflow-gate hook mangled the `<...>` email wrapper, it produced malformed git trailers.

## What changed
Removed the trailer line (and its orphaned preceding blank line) from:
- `skills/smith-new/SKILL.md` (1)
- `skills/smith-build/SKILL.md` (2)
- `skills/smith-bugfix/SKILL.md` (1)
- `skills/smith-finish/SKILL.md` (2)
- `skills/smith-sync/SKILL.md` (1)

Commit subjects/bodies are otherwise unchanged; all `git commit` command blocks remain syntactically valid (closing quotes / heredoc terminators preserved).

## Test plan
- [x] `grep -rn "Co-Authored-By" skills/` returns ZERO matches
- [x] `bash -n` on every modified commit block passes (heredoc + quoted-string forms)
- [x] Only the 5 SKILL.md files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)