### PR TITLE
fix: make workflow-gate redirect detection quote-aware

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -51,3 +51,13 @@ jobs:
           SKILL_COUNT=$(ls -d "$HOME/.claude/skills/smith"* 2>/dev/null | wc -l)
           [ "$SKILL_COUNT" -eq 0 ] || { echo "FAIL: Skills not cleaned up"; exit 1; }
           echo "Uninstall clean"
+
+      - name: Run shell tests
+        run: |
+          fail=0
+          for t in tests/*.test.sh; do
+            [ -f "$t" ] || continue
+            echo "=== $t ==="
+            bash "$t" || fail=1
+          done
+          [ "$fail" -eq 0 ] || { echo "FAIL: one or more shell tests failed"; exit 1; }

--- a/hooks/workflow-gate.sh
+++ b/hooks/workflow-gate.sh
@@ -253,6 +253,55 @@ print(ti.get('command', ''))
             exit 0
         fi
 
+        # Build a redirect-test copy of COMMAND with the CONTENTS of quoted
+        # spans blanked out, so a '>' that lives inside '...' or "..." (a git
+        # trailer like <a@b.com>, an echo banner, a --format string) is not
+        # mistaken for a shell redirect. Real redirects (foo > bar) keep their
+        # '>' OUTSIDE quotes and still trip the check below.
+        #
+        # FAIL-SAFE: the stripper is conservative. If quoting is unbalanced or
+        # otherwise ambiguous, it returns the command UNCHANGED, so the raw
+        # text is tested and we fall back to the original (blocking) behavior.
+        # Worst case is a false block, never a missed real redirect.
+        REDIR_TEST=$(printf '%s' "$COMMAND" | python3 -c '
+import sys
+s = sys.stdin.read()
+out = []
+i = 0
+n = len(s)
+quote = None  # None, "\x27" (single), or "\x22" (double)
+ok = True
+while i < n:
+    c = s[i]
+    if quote is None:
+        if c == "\x27" or c == "\x22":
+            quote = c
+            out.append(" ")  # blank the opening quote
+        else:
+            out.append(c)
+    else:
+        # Inside a quote. Single quotes are literal in shell (no escapes).
+        # Double quotes allow backslash-escapes; treat \\X as two blanked chars.
+        if c == "\\" and quote == "\x22" and i + 1 < n:
+            out.append("  ")
+            i += 2
+            continue
+        if c == quote:
+            quote = None
+            out.append(" ")  # blank the closing quote
+        else:
+            out.append(" ")  # blank the quoted content
+    i += 1
+if quote is not None:
+    ok = False  # unterminated quote → ambiguous
+# On any ambiguity, hand back the ORIGINAL so the raw text is tested (block).
+sys.stdout.write("".join(out) if ok else s)
+' 2>/dev/null || printf '%s' "$COMMAND")
+        # If python3 was unavailable, REDIR_TEST falls back to the raw command.
+        if [ -z "$REDIR_TEST" ]; then
+            REDIR_TEST="$COMMAND"
+        fi
+
         # Identify the first file-touching subcommand, if any.
         # Word-boundary check against known mutators; also detect `sed -i`
         # and unescaped shell write-redirection that isn't a stderr-only
@@ -275,18 +324,19 @@ print(ti.get('command', ''))
         fi
 
         # Shell redirection: > or >> but NOT 2> or 2>>. Also accept &>.
-        # Avoid matching things like ">" inside quoted strings — best-effort.
+        # Tested against REDIR_TEST (quoted spans blanked) so a '>' inside a
+        # quoted string is not a false positive; a real redirect survives.
         if [ -z "$MATCHED_SUBCMD" ]; then
-            if printf '%s' "$COMMAND" | grep -qE '(^|[^0-9&])>>?[^&|]'; then
+            if printf '%s' "$REDIR_TEST" | grep -qE '(^|[^0-9&])>>?[^&|]'; then
                 # Subtract stderr-only redirections.
                 # Strip 2> 2>> from a copy and re-check.
-                stripped=$(printf '%s' "$COMMAND" | sed -E 's/2>>?//g')
+                stripped=$(printf '%s' "$REDIR_TEST" | sed -E 's/2>>?//g')
                 if printf '%s' "$stripped" | grep -qE '(^|[^0-9&])>>?[^&|]'; then
                     MATCHED_SUBCMD="redirection (>, >>)"
                 fi
             fi
             # Match combined-stream redirect: &>
-            if [ -z "$MATCHED_SUBCMD" ] && printf '%s' "$COMMAND" | grep -qE '&>'; then
+            if [ -z "$MATCHED_SUBCMD" ] && printf '%s' "$REDIR_TEST" | grep -qE '&>'; then
                 MATCHED_SUBCMD="redirection (&>)"
             fi
         fi

--- a/tests/workflow-gate-redirect.test.sh
+++ b/tests/workflow-gate-redirect.test.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# workflow-gate-redirect.test.sh — regression tests for the quote-aware
+# redirect detection in hooks/workflow-gate.sh.
+#
+# Drives the REAL hook end-to-end: builds a throwaway git repo with a .smith/
+# dir and NO active-workflow marker (so the gate is armed), pipes a PreToolUse
+# Bash payload, and asserts whether the hook DENIES (redirect detected) or
+# ALLOWS (read-only / quoted '>' is not a redirect).
+#
+# Asserting on the hook's actual output means the test can't drift from the
+# implementation. Prints PASS/FAIL per case + a summary; exits non-zero on any
+# failure so it can run in CI.
+
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd -P)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd -P)
+HOOK="$REPO_ROOT/hooks/workflow-gate.sh"
+
+if [ ! -f "$HOOK" ]; then
+    echo "FATAL: hook not found: $HOOK" >&2
+    exit 2
+fi
+
+PASS=0
+FAIL=0
+
+# A marker-less Smith project so the gate is armed.
+FIXTURE=$(mktemp -d)
+(
+    cd "$FIXTURE" || exit 1
+    git init -q
+    git config user.email test@example.com
+    git config user.name test
+    mkdir -p .smith/vault/active-workflows   # exists but EMPTY → no marker
+)
+cleanup() { rm -rf "$FIXTURE"; }
+trap cleanup EXIT
+
+# run_hook <command-string> -> prints "DENY" or "ALLOW"
+# Feeds a PreToolUse Bash payload to the hook with CLAUDE_PROJECT_DIR=fixture.
+run_hook() {
+    local cmd="$1"
+    local payload
+    payload=$(CMD="$cmd" python3 -c '
+import json, os
+print(json.dumps({
+    "tool_name": "Bash",
+    "tool_input": {"command": os.environ["CMD"]},
+}))')
+    local out
+    out=$(printf '%s' "$payload" | CLAUDE_PROJECT_DIR="$FIXTURE" bash "$HOOK" 2>/dev/null)
+    # The hook prints a JSON deny object when blocking; empty/exit-0 when allowing.
+    if printf '%s' "$out" | grep -q '"permissionDecision": "deny"'; then
+        echo "DENY"
+    else
+        echo "ALLOW"
+    fi
+}
+
+# assert <expected DENY|ALLOW> <command> <label>
+assert() {
+    local expected="$1" cmd="$2" label="$3"
+    local got
+    got=$(run_hook "$cmd")
+    if [ "$got" = "$expected" ]; then
+        echo "PASS [$expected] $label"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL  expected=$expected got=$got :: $label"
+        echo "        cmd: $cmd"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+echo "=== SHOULD NOT BLOCK (quoted '>' / '<' is not a redirect) ==="
+assert ALLOW 'git commit -m "msg <a@b.com>"'              'git trailer with <email> in double quotes'
+assert ALLOW 'echo "=== >>> banner <<< ==="'              'echo banner with >>> and <<< quoted'
+assert ALLOW "git log --format='%an <%ae>'"               'git log --format with <%ae> single-quoted'
+assert ALLOW "grep '# >>> marker'"                        'grep pattern with >>> single-quoted'
+assert ALLOW 'echo "a -> b"'                              'echo arrow a -> b quoted'
+assert ALLOW 'git commit -m "fix: handle a<b and c>d cases"' 'inequality glyphs inside quoted commit msg'
+
+echo ""
+echo "=== SHOULD BLOCK (real redirects still caught) ==="
+assert DENY 'echo x > file.txt'                           'plain > redirect'
+assert DENY 'cat a >> b'                                  'append >> redirect'
+assert DENY 'foo &> out'                                  'combined &> redirect'
+assert DENY 'command > /tmp/x'                            'redirect to absolute path'
+assert DENY 'echo hello > out.txt'                        'unquoted redirect after echo'
+
+echo ""
+echo "=== FAIL-SAFE (ambiguous/unbalanced quoting → block) ==="
+assert DENY 'echo "unterminated > thing'                  'unbalanced double-quote with > → fail-safe block'
+
+echo ""
+echo "=== sanity: real mutators still blocked (unchanged behavior) ==="
+assert DENY 'rm -rf /tmp/x'                               'rm still blocked'
+assert DENY "sed -i 's/a/b/' file"                        'sed -i still blocked'
+
+echo ""
+echo "--- $PASS passed, $FAIL failed ---"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary
- The workflow-gate hook treated any `>` / `<` as a shell redirect, even inside quoted strings, wrongly blocking common commands (git trailers with `<email>`, `echo` banners with `>>>`, `git log --format='%an <%ae>'`, grep patterns). One commit trailer got mangled as a direct result.

## What was broken
`hooks/workflow-gate.sh` ran its redirect regex (`(^|[^0-9&])>>?[^&|]`) against the **whole** command with no quote-awareness — the inline comment even admitted "best-effort" but did nothing.

## What changed
- **hooks/workflow-gate.sh**: before the redirect check, build a copy of the command with the **contents of quoted spans blanked out**, and test `>` / `>>` / `&>` against that copy. A real redirect (`foo > bar`) keeps its `>` outside quotes and is still caught; a quoted `>` vanishes. **Fail-safe**: unbalanced/ambiguous quoting → return the command unchanged → raw text tested → blocks (never a missed real redirect); python3 unavailable → falls back to raw command. All other detections (mutator words, `sed -i`, `2>`/`2>>` stderr subtraction, `&>`, the `create-active-workflow.sh` exemption) are preserved untouched.
- **tests/workflow-gate-redirect.test.sh** (new): drives the **real hook** end-to-end with 14 cases — quoted-`>`-not-blocked, real-redirects-still-blocked, fail-safe unbalanced-quote, and unchanged `rm`/`sed -i` behavior.
- **.github/workflows/test-install.yml**: added a step running `tests/*.test.sh` so this (and the existing shell tests) run in CI.

## Test plan
- [x] `bash -n hooks/workflow-gate.sh` passes
- [x] New regression test: 14/14 pass against the real hook
- [x] All `tests/*.test.sh` pass CI-style (the 2 pre-existing tests still green)
- [x] Scope: hook + new test + CI step only

🤖 Generated with [Claude Code](https://claude.com/claude-code)