### PR TITLE
fix: invoke workflow-summary.sh from global ~/.claude/hooks path

### DIFF
--- a/skills/smith-bugfix/SKILL.md
+++ b/skills/smith-bugfix/SKILL.md
@@ -367,7 +367,7 @@ Emit a final chat message to the user that starts with "Bugfix complete. Here's 
 # $SESSION was captured at workflow start (Phase 1 step 2). Fall back to the
 # marker's session_log field, then to .current-session, if not in scope here.
 SESSION="${SESSION:-$(cat .smith/vault/.current-session 2>/dev/null)}"
-bash hooks/workflow-summary.sh --totals-only --session "$SESSION"
+bash "$HOME/.claude/hooks/workflow-summary.sh" --totals-only --session "$SESSION"
 ```
 If it prints `n/a (no workflow invocation found)` and exits non-zero, do NOT present those as real numbers — note that totals were unavailable and which session file was checked.
 

--- a/skills/smith-debug/SKILL.md
+++ b/skills/smith-debug/SKILL.md
@@ -366,7 +366,7 @@ Would you like me to:
   ```bash
   # $SESSION was captured at workflow start. Fall back to .current-session.
   SESSION="${SESSION:-$(cat .smith/vault/.current-session 2>/dev/null)}"
-  bash hooks/workflow-summary.sh --totals-only --session "$SESSION"
+  bash "$HOME/.claude/hooks/workflow-summary.sh" --totals-only --session "$SESSION"
   ```
   If it prints `n/a (no workflow invocation found)` and exits non-zero, do NOT present those as real numbers — note totals were unavailable and which session file was checked.
 - The full `=== Workflow Summary ===` block is appended to the session log file automatically by the `workflow-summary.sh` Stop hook once the active-workflow file is cleaned up — that's for audit only, do not duplicate it in chat

--- a/skills/smith-new/SKILL.md
+++ b/skills/smith-new/SKILL.md
@@ -451,7 +451,7 @@ After answers are confirmed. All work continues in `WORKTREE_PATH`. The user's m
    # $SESSION was captured at workflow start (step 0). Fall back to the marker's
    # session_log field, then to .current-session, if it's not in scope here.
    SESSION="${SESSION:-$(cat .smith/vault/.current-session 2>/dev/null)}"
-   bash hooks/workflow-summary.sh --totals-only --session "$SESSION"
+   bash "$HOME/.claude/hooks/workflow-summary.sh" --totals-only --session "$SESSION"
    ```
    The bash invocation is a required action, not an optional extra — the totals lines must appear in the chat message. If it prints `n/a (no workflow invocation found)` and exits non-zero, do NOT present those as real numbers — note that totals were unavailable and which session file was checked.
 


### PR DESCRIPTION
## Summary
- Switch the token-totals helper invocation in `smith-new`, `smith-bugfix`, and `smith-debug` from the project-relative `hooks/workflow-summary.sh` to the global `"$HOME/.claude/hooks/workflow-summary.sh"`.
- Removes the requirement that every project carry a local copy of the script.

## What was broken
Projects without a local `hooks/workflow-summary.sh` (e.g. ones that fell behind on `/smith-update`, like goldcanna-inventory) hit a missing-file error when the skill ran `bash hooks/workflow-summary.sh --totals-only`. The workflow then closed with **"Token totals: unavailable"** instead of real numbers.

## What changed
- `skills/smith-new/SKILL.md` — final-summary invocation now uses the global path
- `skills/smith-bugfix/SKILL.md` — same
- `skills/smith-debug/SKILL.md` — same

The script already self-resolves its `workflow_summary_lib.py` dependency from `$HOME/.claude/hooks` first (see `workflow-summary.sh` resolution loop), and `install.sh` copies the script + lib + `pricing.json` into `~/.claude/hooks`, so the global invocation is fully supported with no per-project file. Pure global-path form chosen (no project-local fallback) — confirmed no project currently ships a local override.

## Test plan
- [x] Verified the global invocation resolves and runs from a directory with no local `hooks/` dir (simulating goldcanna): produces graceful `n/a` output, not a missing-file error
- [x] Confirmed `install.sh` populates `~/.claude/hooks` with the script and its Python lib
- [x] No remaining project-relative `bash hooks/workflow-summary.sh` invocations in `skills/`
- [ ] Unit tests — n/a (markdown skill docs only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)