### PR TITLE
fix: stop ## Recent Changes from bloating @-referenced context (BANK-005/026)

### DIFF
--- a/skills/smith/SKILL.md
+++ b/skills/smith/SKILL.md
@@ -445,6 +445,15 @@ See `.specify/memory/constitution.md` for binding project principles.
 - Generate actual commands based on the real package manager and frameworks
 - If existing CLAUDE.md was found and user chose to preserve, merge new sections with existing content
 - Include the SpecKit Workflow section verbatim — this is the standard workflow
+- **Do NOT add a `## Recent Changes` / changelog section, and do NOT `@`-reference
+  a doc that any workflow then appends per-change prose to** (e.g. a `data-model.md`
+  with a growing "Last Updated" header). `@`-referenced files are loaded into context
+  **in full, every session**, and per-change appends turn them into multi-hundred-KB
+  context sinks that also cause merge conflicts on every branch. The durable
+  per-change record already lives in `.smith/vault/sessions/` + the Ledger + git —
+  **those ARE the changelog.** Keep `CLAUDE.md` and any `@`-referenced doc small and
+  stable: structural/durable content only (overview, tech stack, ERD, entity tables,
+  enums), never accumulating history.
 
 **Monorepo-specific CLAUDE.md content** (only if monorepo detected):
 

--- a/skills/smith/scripts/update-agent-context.sh
+++ b/skills/smith/scripts/update-agent-context.sh
@@ -318,16 +318,6 @@ create_new_agent_file() {
         tech_stack="- ($escaped_branch)"
     fi
 
-    local recent_change
-    if [[ -n "$escaped_lang" && -n "$escaped_framework" ]]; then
-        recent_change="- $escaped_branch: Added $escaped_lang + $escaped_framework"
-    elif [[ -n "$escaped_lang" ]]; then
-        recent_change="- $escaped_branch: Added $escaped_lang"
-    elif [[ -n "$escaped_framework" ]]; then
-        recent_change="- $escaped_branch: Added $escaped_framework"
-    else
-        recent_change="- $escaped_branch: Added"
-    fi
 
     local substitutions=(
         "s|\[PROJECT NAME\]|$project_name|"
@@ -336,7 +326,6 @@ create_new_agent_file() {
         "s|\[ACTUAL STRUCTURE FROM PLANS\]|$project_structure|g"
         "s|\[ONLY COMMANDS FOR ACTIVE TECHNOLOGIES\]|$commands|"
         "s|\[LANGUAGE-SPECIFIC, ONLY FOR LANGUAGES IN USE\]|$language_conventions|"
-        "s|\[LAST 3 FEATURES AND WHAT THEY ADDED\]|$recent_change|"
     )
     
     for substitution in "${substitutions[@]}"; do
@@ -376,8 +365,7 @@ update_existing_agent_file() {
     # Process the file in one pass
     local tech_stack=$(format_technology_stack "$NEW_LANG" "$NEW_FRAMEWORK")
     local new_tech_entries=()
-    local new_change_entry=""
-    
+
     # Prepare new technology entries
     if [[ -n "$tech_stack" ]] && ! grep -q "$tech_stack" "$target_file"; then
         new_tech_entries+=("- $tech_stack ($CURRENT_BRANCH)")
@@ -387,31 +375,16 @@ update_existing_agent_file() {
         new_tech_entries+=("- $NEW_DB ($CURRENT_BRANCH)")
     fi
     
-    # Prepare new change entry
-    if [[ -n "$tech_stack" ]]; then
-        new_change_entry="- $CURRENT_BRANCH: Added $tech_stack"
-    elif [[ -n "$NEW_DB" ]] && [[ "$NEW_DB" != "N/A" ]] && [[ "$NEW_DB" != "NEEDS CLARIFICATION" ]]; then
-        new_change_entry="- $CURRENT_BRANCH: Added $NEW_DB"
-    fi
-    
     # Check if sections exist in the file
     local has_active_technologies=0
-    local has_recent_changes=0
-    
+
     if grep -q "^## Active Technologies" "$target_file" 2>/dev/null; then
         has_active_technologies=1
     fi
-    
-    if grep -q "^## Recent Changes" "$target_file" 2>/dev/null; then
-        has_recent_changes=1
-    fi
-    
+
     # Process file line by line
     local in_tech_section=false
-    local in_changes_section=false
     local tech_entries_added=false
-    local changes_entries_added=false
-    local existing_changes_count=0
     local file_ended=false
     
     while IFS= read -r line || [[ -n "$line" ]]; do
@@ -439,29 +412,6 @@ update_existing_agent_file() {
             continue
         fi
         
-        # Handle Recent Changes section
-        if [[ "$line" == "## Recent Changes" ]]; then
-            echo "$line" >> "$temp_file"
-            # Add new change entry right after the heading
-            if [[ -n "$new_change_entry" ]]; then
-                echo "$new_change_entry" >> "$temp_file"
-            fi
-            in_changes_section=true
-            changes_entries_added=true
-            continue
-        elif [[ $in_changes_section == true ]] && [[ "$line" =~ ^##[[:space:]] ]]; then
-            echo "$line" >> "$temp_file"
-            in_changes_section=false
-            continue
-        elif [[ $in_changes_section == true ]] && [[ "$line" == "- "* ]]; then
-            # Keep only first 2 existing changes
-            if [[ $existing_changes_count -lt 2 ]]; then
-                echo "$line" >> "$temp_file"
-                ((existing_changes_count++))
-            fi
-            continue
-        fi
-        
         # Update timestamp
         if [[ "$line" =~ \*\*Last\ updated\*\*:.*[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9] ]]; then
             echo "$line" | sed "s/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]/$current_date/" >> "$temp_file"
@@ -483,14 +433,7 @@ update_existing_agent_file() {
         printf '%s\n' "${new_tech_entries[@]}" >> "$temp_file"
         tech_entries_added=true
     fi
-    
-    if [[ $has_recent_changes -eq 0 ]] && [[ -n "$new_change_entry" ]]; then
-        echo "" >> "$temp_file"
-        echo "## Recent Changes" >> "$temp_file"
-        echo "$new_change_entry" >> "$temp_file"
-        changes_entries_added=true
-    fi
-    
+
     # Move temp file to target atomically
     if ! mv "$temp_file" "$target_file"; then
         log_error "Failed to update target file"

--- a/skills/smith/templates/agent-file-template.md
+++ b/skills/smith/templates/agent-file-template.md
@@ -20,9 +20,5 @@ Auto-generated from all feature plans. Last updated: [DATE]
 
 [LANGUAGE-SPECIFIC, ONLY FOR LANGUAGES IN USE]
 
-## Recent Changes
-
-[LAST 3 FEATURES AND WHAT THEY ADDED]
-
 <!-- MANUAL ADDITIONS START -->
 <!-- MANUAL ADDITIONS END -->

--- a/templates/constitution-additions.md
+++ b/templates/constitution-additions.md
@@ -12,6 +12,24 @@ SHOULD be decomposed unless they are:
 in audit reports and PR descriptions respectively. None of these checks
 block — they inform.
 
+## Context Budget Policy (`@`-Referenced Files)
+
+Files `@`-referenced from `CLAUDE.md` (or any always-loaded memory file) are read
+**in full into every session's context**. They MUST stay small and structurally
+stable — overview, tech stack, ERD, entity tables, enums, durable notes only.
+
+- Do NOT `@`-reference a doc that any workflow or rule then appends per-change
+  prose to (a growing "Last Updated" / "Recent Changes" changelog header is the
+  classic offender — it silently grows to hundreds of KB and causes merge
+  conflicts on every branch).
+- The durable per-change record lives in `.smith/vault/sessions/` + the Ledger +
+  git history — **those ARE the changelog.** Do not hand-roll a
+  `feedback_changelog.md`-style rule that re-introduces per-change appends into a
+  context-loaded file.
+- As a soft target, keep any single `@`-referenced file under ~50 KB. `/dream`
+  (or the project's config-health auditor) REPORTS oversized `@`-referenced files
+  in its health summary — it never edits them.
+
 ## Project Manifest
 
 The project manifest under `.smith/index/` is auto-maintained by the


### PR DESCRIPTION
## Summary
- Removes the `## Recent Changes` changelog writer from Smith-core scaffolding so `@`-referenced docs (CLAUDE.md, data-model.md) stop accumulating per-change prose that's loaded **in full into every session's context**.
- Adds a context-budget guardrail to `/smith` scaffolding + the constitution template.
- Resolves the REQUIRED part of **BANK-005** and all of **BANK-026**. Decision (2026-06-26): no new changelog artifact — sessions + ledger + git ARE the changelog.

## What was broken
- `update-agent-context.sh` prepended a `## Recent Changes` bullet, capped to 2 entries, AND **recreated the section after deletion** — so removing it from a project's CLAUDE.md never stuck.
- Combined with per-project `feedback_changelog.md`-style rules, this drove model-authored long-prose appends into context-loaded files (observed: a 683 KB `data-model.md` `@`-referenced from CLAUDE.md), causing both context bloat and CLAUDE.md merge conflicts on every branch.

## What changed
- **`skills/smith/scripts/update-agent-context.sh`** — removed the `recent_change` var, the `[LAST 3 FEATURES...]` substitution, `new_change_entry`, the `## Recent Changes` detection, the in-loop prepend+cap-to-2 handler, and the recreate-when-absent block. Active Technologies + timestamp logic untouched (verified byte-identical to `origin/main`).
- **`skills/smith/templates/agent-file-template.md`** — removed the `## Recent Changes` block + `[LAST 3 FEATURES...]` placeholder so freshly scaffolded projects never get the section.
- **`skills/smith/SKILL.md`** — added a CLAUDE.md-generation rule: never add a changelog section, never `@`-reference a doc a workflow then appends to.
- **`templates/constitution-additions.md`** — added a "Context Budget Policy (`@`-Referenced Files)" section (~50 KB soft cap; `/dream` reports, never edits).

### Stream B note
A data-model.md "Last Updated" writer in smith-core was confirmed a **no-op** — no such writer exists in any SKILL/template (`grep "Last Updated" skills/` is empty). The GoldCanna bloat came from that project's own `feedback_changelog.md` rule, handled per-project.

## Test plan
- [x] `bash -n` passes; no residual references to removed vars
- [x] Pre-existing `## Recent Changes` now passes through untouched (no prepend, no cap)
- [x] Absent section is NOT recreated (recurrence bug fixed)
- [x] Timestamp update + Active Technologies behavior unchanged vs `origin/main`
- N/A Docker / E2E (docs + shell scaffolding only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)