### PR TITLE
feat: context-budget-guard hook for @-referenced file bloat (BANK-026)

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -15,6 +15,7 @@ To disable any hook, remove its entry from `~/.claude/settings.json`. The script
 | grade-response | Stop | * | Grade response against CLAUDE.md rubric; block stop and retry if score < 100 |
 | file-change-logger | PostToolUse | Write, Edit, NotebookEdit | Log file changes to session |
 | lint-on-save | PostToolUse | Write, Edit | Run linter on saved files |
+| context-budget-guard | PostToolUse | Write, Edit | Warn when an edited file exceeds the size soft cap (default 50 KB); flag `@`-referenced files loudly |
 | security-guard-bash | PreToolUse | Bash | Block dangerous commands |
 | security-guard-files | PreToolUse | Write, Edit, NotebookEdit | Block writes to sensitive files |
 | task-router | PreToolUse | Task | Route tasks during workflows |
@@ -74,6 +75,17 @@ To disable any hook, remove its entry from `~/.claude/settings.json`. The script
 - **What it does:** Fires after file writes and edits. Detects the file type and runs the appropriate linter if one is available (e.g., eslint for JavaScript/TypeScript, ruff for Python, shellcheck for bash). Reports lint errors back to Claude Code so they can be addressed immediately. If no linter is found for the file type, the hook exits silently.
 - **Files touched:** Reads the saved file; does not modify any files
 - **To disable:** Remove the `PostToolUse` entry referencing this script from `settings.json`.
+
+---
+
+### context-budget-guard.sh
+
+- **Event:** PostToolUse
+- **Matcher:** `Write`, `Edit`
+- **What it does:** Fires after file writes and edits. Stats the saved file and, if it exceeds the size soft cap, prints an advisory to stderr. Files that are `@`-referenced from the project `CLAUDE.md` are flagged extra-loudly because they are loaded **in full into every session's context** — re-growth there is the expensive case (e.g. a `data-model.md` accumulating per-change changelog prose). The guard never blocks; it always exits 0.
+- **Configuration:** Reads `context_budget.max_file_kb` from `.smith/config.json` (default `50`). Set it to `0` to disable the guard entirely. Seeded by `templates/config.default.json`.
+- **Files touched:** Reads the saved file and `CLAUDE.md`; does not modify any files
+- **To disable:** Set `context_budget.max_file_kb` to `0` in `.smith/config.json`, or remove the `PostToolUse` entry referencing this script from `settings.json`.
 
 ---
 

--- a/hooks/context-budget-guard.sh
+++ b/hooks/context-budget-guard.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# context-budget-guard.sh
+# Event: PostToolUse
+# Matcher: Write|Edit
+# Scope: Universal (main session + sub-agents)
+#
+# Warns (never blocks) when a just-written file crosses a size threshold.
+# Files that are @-referenced from CLAUDE.md are flagged extra-loudly because
+# they are loaded IN FULL into every session's context — re-growth there is the
+# expensive case this guard exists to catch at the moment of writing.
+#
+# Threshold is configurable via .smith/config.json:
+#   { "context_budget": { "max_file_kb": 50 } }
+# Defaults to 50 KB when the key (or the file) is absent. Set max_file_kb to 0
+# to disable the guard entirely.
+#
+# This hook is advisory: it prints to stderr and always exits 0.
+
+set -uo pipefail
+
+# Consume stdin (hook input JSON)
+INPUT=$(cat)
+
+# Extract file_path from tool_input
+FILE_PATH=$(echo "$INPUT" | grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"file_path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/' || echo "")
+
+if [ -z "$FILE_PATH" ] || [ ! -f "$FILE_PATH" ]; then
+    exit 0
+fi
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+
+# --- Resolve threshold (KB) from config; default 50, 0 disables -------------
+THRESHOLD_KB=50
+CONFIG_FILE="$PROJECT_DIR/.smith/config.json"
+if [ -f "$CONFIG_FILE" ] && command -v python3 >/dev/null 2>&1; then
+    CFG_KB=$(python3 -c "import json,sys; d=json.load(open('$CONFIG_FILE')); print(d.get('context_budget',{}).get('max_file_kb',50))" 2>/dev/null || echo "")
+    case "$CFG_KB" in
+        ''|*[!0-9]*) : ;;          # non-numeric / empty → keep default
+        *) THRESHOLD_KB="$CFG_KB" ;;
+    esac
+fi
+
+# 0 disables the guard.
+if [ "$THRESHOLD_KB" -eq 0 ] 2>/dev/null; then
+    exit 0
+fi
+
+# --- File size in bytes (portable: BSD then GNU stat) -----------------------
+SIZE_BYTES=$(stat -f%z "$FILE_PATH" 2>/dev/null || stat -c%s "$FILE_PATH" 2>/dev/null || echo 0)
+THRESHOLD_BYTES=$((THRESHOLD_KB * 1024))
+
+if [ "$SIZE_BYTES" -le "$THRESHOLD_BYTES" ] 2>/dev/null; then
+    exit 0
+fi
+
+SIZE_KB=$((SIZE_BYTES / 1024))
+REL_PATH="${FILE_PATH#$PROJECT_DIR/}"
+
+# --- Is this file @-referenced from the project CLAUDE.md? ------------------
+# @-referenced files are loaded in full every session — the expensive case.
+IS_AT_REFERENCED=false
+CLAUDE_MD="$PROJECT_DIR/CLAUDE.md"
+if [ -f "$CLAUDE_MD" ]; then
+    # Match a leading-@ reference to this file by its project-relative path or
+    # basename (e.g. "@docs/data-model.md" or "@data-model.md").
+    BASENAME=$(basename "$FILE_PATH")
+    if grep -Eq "@(${REL_PATH//\//\\/}|[^[:space:]]*/${BASENAME}|${BASENAME})([[:space:]]|\$)" "$CLAUDE_MD" 2>/dev/null; then
+        IS_AT_REFERENCED=true
+    fi
+fi
+
+if [ "$IS_AT_REFERENCED" = true ]; then
+    {
+        echo "⚠️  CONTEXT BUDGET: $REL_PATH is ${SIZE_KB} KB and is @-referenced from CLAUDE.md."
+        echo "    @-referenced files load IN FULL into every session's context. This one"
+        echo "    exceeds the ${THRESHOLD_KB} KB soft cap — likely accumulating per-change prose."
+        echo "    Keep it to durable/structural content only (ERD, tables, enums, notes);"
+        echo "    per-change history belongs in .smith/vault/sessions/ + ledger + git."
+    } >&2
+else
+    echo "⚠️  CONTEXT BUDGET: $REL_PATH is ${SIZE_KB} KB (> ${THRESHOLD_KB} KB soft cap). Consider trimming or decomposing." >&2
+fi
+
+exit 0

--- a/settings/smith-settings-fragment.json
+++ b/settings/smith-settings-fragment.json
@@ -41,6 +41,7 @@
         "matcher": "Write|Edit",
         "hooks": [
           { "type": "command", "command": "bash ~/.claude/hooks/lint-on-save.sh" },
+          { "type": "command", "command": "bash ~/.claude/hooks/context-budget-guard.sh" },
           { "type": "command", "command": "bash ~/.claude/hooks/manifest-updater.sh" }
         ]
       },

--- a/templates/config.default.json
+++ b/templates/config.default.json
@@ -9,6 +9,10 @@
     "production_domains": [],
     "warn_only_mode": false
   },
+  "context_budget": {
+    "_comment": "context-budget-guard.sh warns (never blocks) when an edited file exceeds max_file_kb. @-referenced files (loaded in full every session) are flagged extra-loudly. Set max_file_kb to 0 to disable.",
+    "max_file_kb": 50
+  },
   "ledger": {
     "enabled": true,
     "auto_reflect": true,

--- a/tests/hooks/test_context_budget_guard.sh
+++ b/tests/hooks/test_context_budget_guard.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Unit tests for context-budget-guard.sh (PostToolUse Write|Edit hook).
+#
+# Verifies:
+#   - Small file (<= threshold) → silent, exit 0
+#   - Large non-@-referenced file → generic soft-cap warning on stderr
+#   - Large @-referenced file (in CLAUDE.md) → loud @-referenced warning
+#   - Threshold is configurable via .smith/config.json (context_budget.max_file_kb)
+#   - max_file_kb = 0 disables the guard
+#   - Hook never blocks (always exits 0) and tolerates missing file / bad JSON
+#   - settings/smith-settings-fragment.json wires the hook in the Write|Edit
+#     chain BEFORE manifest-updater.sh (which must remain LAST)
+#
+# Run:
+#   bash tests/hooks/test_context_budget_guard.sh
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+HOOK="$REPO/hooks/context-budget-guard.sh"
+FRAGMENT="$REPO/settings/smith-settings-fragment.json"
+CONFIG_DEFAULT="$REPO/templates/config.default.json"
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+assert() {
+    if [ "$2" = "true" ]; then
+        PASS=$((PASS+1))
+    else
+        FAIL=$((FAIL+1))
+        FAILED_NAMES+=("$1")
+        echo "FAIL $1"
+    fi
+}
+
+run_hook() {
+    # $1 = project dir, $2 = file path
+    echo "{\"tool_name\":\"Write\",\"tool_input\":{\"file_path\":\"$2\"}}" \
+        | CLAUDE_PROJECT_DIR="$1" bash "$HOOK" 2>&1
+}
+
+WORK=$(mktemp -d -t cbg.XXXXXX)
+trap 'rm -rf "$WORK"' EXIT
+mkdir -p "$WORK/.smith" "$WORK/docs"
+
+# --- small file → silent --------------------------------------------------
+echo "small content" > "$WORK/docs/small.md"
+OUT=$(run_hook "$WORK" "$WORK/docs/small.md")
+[ -z "$OUT" ] && assert "small file silent" true || assert "small file silent (got: $OUT)" false
+
+# --- large non-@-ref file → generic warning -------------------------------
+python3 -c "open('$WORK/docs/big.md','w').write('x'*60000)"
+OUT=$(run_hook "$WORK" "$WORK/docs/big.md")
+echo "$OUT" | grep -q "soft cap" && assert "large file generic warning" true \
+    || assert "large file generic warning (got: $OUT)" false
+echo "$OUT" | grep -q "@-referenced" && assert "non-@-ref must NOT claim @-ref (got: $OUT)" false \
+    || assert "non-@-ref not flagged as @-ref" true
+
+# --- large @-ref file → loud warning --------------------------------------
+printf '# CLAUDE.md\n@docs/big.md\n' > "$WORK/CLAUDE.md"
+OUT=$(run_hook "$WORK" "$WORK/docs/big.md")
+echo "$OUT" | grep -q "@-referenced from CLAUDE.md" && assert "@-ref file loud warning" true \
+    || assert "@-ref file loud warning (got: $OUT)" false
+
+# --- @-ref detection by basename too --------------------------------------
+printf '# CLAUDE.md\n@big.md\n' > "$WORK/CLAUDE.md"
+OUT=$(run_hook "$WORK" "$WORK/docs/big.md")
+echo "$OUT" | grep -q "@-referenced from CLAUDE.md" && assert "@-ref detected by basename" true \
+    || assert "@-ref detected by basename (got: $OUT)" false
+rm -f "$WORK/CLAUDE.md"
+
+# --- configurable threshold (raise to 100KB → 60KB file silent) -----------
+echo '{"context_budget":{"max_file_kb":100}}' > "$WORK/.smith/config.json"
+OUT=$(run_hook "$WORK" "$WORK/docs/big.md")
+[ -z "$OUT" ] && assert "threshold raised silences 60KB" true \
+    || assert "threshold raised silences 60KB (got: $OUT)" false
+
+# --- max_file_kb=0 disables -----------------------------------------------
+echo '{"context_budget":{"max_file_kb":0}}' > "$WORK/.smith/config.json"
+OUT=$(run_hook "$WORK" "$WORK/docs/big.md")
+[ -z "$OUT" ] && assert "max_file_kb=0 disables" true \
+    || assert "max_file_kb=0 disables (got: $OUT)" false
+
+# --- default 50KB when no config ------------------------------------------
+rm -f "$WORK/.smith/config.json"
+OUT=$(run_hook "$WORK" "$WORK/docs/big.md")
+echo "$OUT" | grep -q "50 KB soft cap" && assert "defaults to 50KB without config" true \
+    || assert "defaults to 50KB without config (got: $OUT)" false
+
+# --- never blocks (exit 0) ------------------------------------------------
+echo "{\"tool_name\":\"Write\",\"tool_input\":{\"file_path\":\"$WORK/docs/big.md\"}}" \
+    | CLAUDE_PROJECT_DIR="$WORK" bash "$HOOK" >/dev/null 2>&1
+assert "exits 0 on warning" "$([ $? -eq 0 ] && echo true || echo false)"
+
+# --- missing file → silent ------------------------------------------------
+OUT=$(run_hook "$WORK" "$WORK/nope.md")
+[ -z "$OUT" ] && assert "missing file silent" true || assert "missing file silent (got: $OUT)" false
+
+# --- malformed JSON → no crash --------------------------------------------
+OUT=$(echo "not json" | CLAUDE_PROJECT_DIR="$WORK" bash "$HOOK" 2>&1)
+assert "malformed JSON exits 0" "$([ $? -eq 0 ] && echo true || echo false)"
+
+# --- settings fragment wiring ---------------------------------------------
+python3 -c "import json; json.load(open('$FRAGMENT'))" 2>/dev/null \
+    && assert "settings fragment valid JSON" true || assert "settings fragment valid JSON" false
+
+# context-budget-guard registered in a Write|Edit block, BEFORE manifest-updater
+ORDER_OK=$(python3 -c "
+import json
+s = json.load(open('$FRAGMENT'))
+for block in s['hooks']['PostToolUse']:
+    if block.get('matcher') == 'Write|Edit':
+        cmds = [h['command'] for h in block['hooks']]
+        cbg = next((i for i,c in enumerate(cmds) if 'context-budget-guard' in c), None)
+        mu  = next((i for i,c in enumerate(cmds) if 'manifest-updater' in c), None)
+        if cbg is not None and mu is not None and cbg < mu:
+            print('1'); break
+else:
+    print('0')
+" 2>/dev/null)
+[ "$ORDER_OK" = "1" ] && assert "guard wired before manifest-updater in Write|Edit" true \
+    || assert "guard wired before manifest-updater in Write|Edit" false
+
+# --- config default has the key -------------------------------------------
+HAS_KEY=$(python3 -c "import json; d=json.load(open('$CONFIG_DEFAULT')); print('1' if d.get('context_budget',{}).get('max_file_kb')==50 else '0')" 2>/dev/null)
+[ "$HAS_KEY" = "1" ] && assert "config.default seeds max_file_kb=50" true \
+    || assert "config.default seeds max_file_kb=50" false
+
+# --- summary --------------------------------------------------------------
+echo "context-budget-guard tests: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || { printf 'failed: %s\n' "${FAILED_NAMES[@]}"; exit 1; }


### PR DESCRIPTION
## Summary
- New **PostToolUse(Write|Edit)** hook that warns the moment an edited file crosses a size soft cap — catching context re-growth at write time instead of waiting for a periodic audit.
- Files `@`-referenced from `CLAUDE.md` (loaded **in full into every session's context**) are flagged extra-loudly — the expensive case (e.g. a `data-model.md` accumulating per-change changelog prose).
- Completes the **optional context-budget guard** from BANK-026 — the durable prevention layer that catches re-bloat the day it happens, complementing the writer-removal in #47.

## What changed
- **`hooks/context-budget-guard.sh`** (new) — stats the saved file, warns to stderr when over threshold, **never blocks** (always exits 0). Portable `stat` (BSD/GNU). Threshold from `.smith/config.json` `context_budget.max_file_kb` (default `50`, `0` disables). Detects `@`-refs by project-relative path or basename in `CLAUDE.md`.
- **`settings/smith-settings-fragment.json`** — wires the guard into the `Write|Edit` chain **before** `manifest-updater.sh` (which stays LAST per Decision 7).
- **`templates/config.default.json`** — seeds `context_budget.max_file_kb = 50`.
- **`docs/hooks.md`** — summary table row + detailed reference entry.
- **`tests/hooks/test_context_budget_guard.sh`** (new) — 14 assertions.

## Test plan
- [x] New suite: **14/14 pass** (threshold, `@`-ref detection by path + basename, config override, `0` disables, default 50 KB, non-blocking exit 0, missing file, malformed JSON, settings-fragment wiring order, config-default key)
- [x] `test_hook_chain_order` **6/6** — no regression (manifest-updater still LAST)
- [x] `test_workflow_gate_exemption` **12/12**
- [x] Both modified JSON files validate
- N/A Docker / E2E (shell hook + scaffolding only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)